### PR TITLE
Add option to not print skipped violations in ConsoleOutputFormatter

### DIFF
--- a/README.md
+++ b/README.md
@@ -361,6 +361,7 @@ formatting dependencies.
 Found 0 Violations and 1 Violations skipped
 ``` 
 
+Use `--report-skipped=false` option to disable reporting skipped violations.
 
 ## Ruleset (Allowing Dependencies)
 

--- a/README.md
+++ b/README.md
@@ -626,8 +626,6 @@ The default formatter is the console formatter, which dumps basic information to
 examples\MyNamespace\Repository\SomeRepository::5 must not depend on examples\MyNamespace\Controllers\SomeController (Repository on Controller)
 ```
 
-Printing skipped violations can be disabled with `--console-print-skipped=false`.
-
 ### Table Formatter
 
 The table formatter groups results by layers to its own table. It can be activated with `--formatter=table`.

--- a/README.md
+++ b/README.md
@@ -626,6 +626,8 @@ The default formatter is the console formatter, which dumps basic information to
 examples\MyNamespace\Repository\SomeRepository::5 must not depend on examples\MyNamespace\Controllers\SomeController (Repository on Controller)
 ```
 
+Printing skipped violations can be disabled with `--console-print-skipped=false`.
+
 ### Table Formatter
 
 The table formatter groups results by layers to its own table. It can be activated with `--formatter=table`.

--- a/src/Console/Command/AnalyzeCommand.php
+++ b/src/Console/Command/AnalyzeCommand.php
@@ -25,6 +25,7 @@ use Symfony\Component\EventDispatcher\EventDispatcherInterface;
 class AnalyzeCommand extends Command
 {
     public const OPTION_REPORT_UNCOVERED = 'report-uncovered';
+    public const OPTION_REPORT_SKIPPED = 'report-skipped';
 
     /** @var Analyser */
     private $analyser;
@@ -67,6 +68,7 @@ class AnalyzeCommand extends Command
         $this->addOption('no-progress', null, InputOption::VALUE_NONE, 'Do not show progress bar');
         $this->addOption('fail-on-uncovered', null, InputOption::VALUE_NONE, 'Fails if any uncovered dependency is found');
         $this->addOption(self::OPTION_REPORT_UNCOVERED, null, InputOption::VALUE_NONE, 'Report uncovered dependencies');
+        $this->addOption(self::OPTION_REPORT_SKIPPED, null, InputOption::VALUE_OPTIONAL, 'Report skipped violations', true);
         $this->getDefinition()->addOptions($this->formatterFactory->getFormatterOptions());
     }
 

--- a/src/OutputFormatter/ConsoleOutputFormatter.php
+++ b/src/OutputFormatter/ConsoleOutputFormatter.php
@@ -18,7 +18,6 @@ final class ConsoleOutputFormatter implements OutputFormatterInterface
 {
     /** @deprecated */
     public const LEGACY_REPORT_UNCOVERED = 'formatter-console-report-uncovered';
-    private const PRINT_SKIPPED = 'console-print-skipped';
 
     /** @var Env */
     private $env;
@@ -37,7 +36,6 @@ final class ConsoleOutputFormatter implements OutputFormatterInterface
     {
         return [
             OutputFormatterOption::newValueOption(self::LEGACY_REPORT_UNCOVERED, '<fg=yellow>[DEPRECATED]</> Report uncovered dependencies.', false),
-            OutputFormatterOption::newValueOption(self::PRINT_SKIPPED, 'Print skipped violations', true),
         ];
     }
 
@@ -59,14 +57,14 @@ final class ConsoleOutputFormatter implements OutputFormatterInterface
             $output->writeLineFormatted('');
         }
 
-        $printSkipped = $outputFormatterInput->getOptionAsBoolean(self::PRINT_SKIPPED);
+        $reportSkipped = $outputFormatterInput->getOptionAsBoolean(AnalyzeCommand::OPTION_REPORT_SKIPPED);
 
         foreach ($context->rules() as $rule) {
             if (!$rule instanceof Violation && !$rule instanceof SkippedViolation) {
                 continue;
             }
 
-            if (!$printSkipped && $rule instanceof SkippedViolation) {
+            if (!$reportSkipped && $rule instanceof SkippedViolation) {
                 continue;
             }
 

--- a/src/OutputFormatter/ConsoleOutputFormatter.php
+++ b/src/OutputFormatter/ConsoleOutputFormatter.php
@@ -18,6 +18,7 @@ final class ConsoleOutputFormatter implements OutputFormatterInterface
 {
     /** @deprecated */
     public const LEGACY_REPORT_UNCOVERED = 'formatter-console-report-uncovered';
+    private const PRINT_SKIPPED = 'console-print-skipped';
 
     /** @var Env */
     private $env;
@@ -36,6 +37,7 @@ final class ConsoleOutputFormatter implements OutputFormatterInterface
     {
         return [
             OutputFormatterOption::newValueOption(self::LEGACY_REPORT_UNCOVERED, '<fg=yellow>[DEPRECATED]</> Report uncovered dependencies.', false),
+            OutputFormatterOption::newValueOption(self::PRINT_SKIPPED, 'Print skipped violations', true),
         ];
     }
 
@@ -57,8 +59,14 @@ final class ConsoleOutputFormatter implements OutputFormatterInterface
             $output->writeLineFormatted('');
         }
 
+        $printSkipped = $outputFormatterInput->getOptionAsBoolean(self::PRINT_SKIPPED);
+
         foreach ($context->rules() as $rule) {
             if (!$rule instanceof Violation && !$rule instanceof SkippedViolation) {
+                continue;
+            }
+
+            if (!$printSkipped && $rule instanceof SkippedViolation) {
                 continue;
             }
 

--- a/tests/OutputFormatter/ConsoleOutputFormatterTest.php
+++ b/tests/OutputFormatter/ConsoleOutputFormatterTest.php
@@ -172,7 +172,7 @@ final class ConsoleOutputFormatterTest extends TestCase
             new OutputFormatterInput([
                 AnalyzeCommand::OPTION_REPORT_UNCOVERED => true,
                 ConsoleOutputFormatter::LEGACY_REPORT_UNCOVERED => false,
-                'console-print-skipped' => true,
+                AnalyzeCommand::OPTION_REPORT_SKIPPED => true,
             ])
         );
 
@@ -208,7 +208,7 @@ final class ConsoleOutputFormatterTest extends TestCase
             new OutputFormatterInput([
                 AnalyzeCommand::OPTION_REPORT_UNCOVERED => true,
                 ConsoleOutputFormatter::LEGACY_REPORT_UNCOVERED => false,
-                'console-print-skipped' => false,
+                AnalyzeCommand::OPTION_REPORT_SKIPPED => false,
             ])
         );
 
@@ -231,7 +231,7 @@ final class ConsoleOutputFormatterTest extends TestCase
 
     public function testGetOptions(): void
     {
-        self::assertCount(2, (new ConsoleOutputFormatter(new EmptyEnv()))->configureOptions());
+        self::assertCount(1, (new ConsoleOutputFormatter(new EmptyEnv()))->configureOptions());
     }
 
     private function normalize($str)


### PR DESCRIPTION
These changes propose a new option that allows hiding skipped violations from the console formatter's output. For depfiles with a long baseline, it is hard to spot new violations amongst skipped ones.