### PR TITLE
readme: fix `classNameRegex` example

### DIFF
--- a/README.md
+++ b/README.md
@@ -488,7 +488,7 @@ layers:
   - name: Controller
     collectors:
       - type: classNameRegex
-        regex: #.*Controller.*#
+        regex: '#.*Controller.*#'
 ```
 
 Every class name that matches the regular expression becomes a part of the *controller* layer.


### PR DESCRIPTION
as is, the example runs into a error:
```
 50/50 [============================] 100%
In ClassNameRegexCollector.php line 24:

  ClassNameRegexCollector needs the regex configuration.
```