### PR TITLE
Exclude classes with `@internal` from collection

### DIFF
--- a/README.md
+++ b/README.md
@@ -630,15 +630,15 @@ layers:
         inherits: 'App\SomeInterface'
 ```
 
-### `marked_internal` Collector
+### `markedInternal` Collector
 
-The `marked_internal` collector collects all classes annotated with `@internal` on the class doc block.
+The `markedInternal` collector collects all classes annotated with `@internal` on the class doc block.
 
 ```
 layers:
   - name: Foo
     collectors:
-      - type: marked_internal
+      - type: markedInternal
 ```
 
 ### Custom Collectors

--- a/README.md
+++ b/README.md
@@ -630,6 +630,17 @@ layers:
         inherits: 'App\SomeInterface'
 ```
 
+### `marked_internal` Collector
+
+The `marked_internal` collector collects all classes annotated with `@internal` on the class doc block.
+
+```
+layers:
+  - name: Foo
+    collectors:
+      - type: marked_internal
+```
+
 ### Custom Collectors
 
 You can even create custom collectors in your project by implementing the `Qossmic\Deptrac\Collector\CollectorInterface`.

--- a/config/services.php
+++ b/config/services.php
@@ -24,6 +24,7 @@ use Qossmic\Deptrac\Collector\ExtendsCollector;
 use Qossmic\Deptrac\Collector\ImplementsCollector;
 use Qossmic\Deptrac\Collector\InheritanceLevelCollector;
 use Qossmic\Deptrac\Collector\InheritsCollector;
+use Qossmic\Deptrac\Collector\MarkedInternalCollector;
 use Qossmic\Deptrac\Collector\MethodCollector;
 use Qossmic\Deptrac\Collector\Registry;
 use Qossmic\Deptrac\Collector\UsesCollector;
@@ -207,6 +208,9 @@ return static function (ContainerConfigurator $container): void {
     $services
         ->set(MethodCollector::class)
         ->args([service(NikicPhpParser::class)])
+        ->tag('collector');
+    $services
+        ->set(MarkedInternalCollector::class)
         ->tag('collector');
 
     /* Dependency resolving */

--- a/src/AstRunner/AstMap/AstClassReference.php
+++ b/src/AstRunner/AstMap/AstClassReference.php
@@ -18,15 +18,19 @@ class AstClassReference
     /** @var AstInherit[] */
     private $inherits;
 
+    /** @var bool */
+    private $internal;
+
     /**
      * @param AstInherit[]    $inherits
      * @param AstDependency[] $dependencies
      */
-    public function __construct(ClassLikeName $classLikeName, array $inherits = [], array $dependencies = [])
+    public function __construct(ClassLikeName $classLikeName, array $inherits = [], array $dependencies = [], bool $internal = false)
     {
         $this->classLikeName = $classLikeName;
         $this->dependencies = $dependencies;
         $this->inherits = $inherits;
+        $this->internal = $internal;
     }
 
     public function withFileReference(AstFileReference $astFileReference): self
@@ -61,5 +65,10 @@ class AstClassReference
     public function getInherits(): array
     {
         return $this->inherits;
+    }
+
+    public function isInternal(): bool
+    {
+        return $this->internal;
     }
 }

--- a/src/AstRunner/AstMap/ClassReferenceBuilder.php
+++ b/src/AstRunner/AstMap/ClassReferenceBuilder.php
@@ -18,6 +18,9 @@ final class ClassReferenceBuilder
     /** @var AstDependency[] */
     private $dependencies = [];
 
+    /** @var bool */
+    private $internal = false;
+
     private function __construct(string $filepath, string $classLikeName)
     {
         $this->filepath = $filepath;
@@ -35,7 +38,8 @@ final class ClassReferenceBuilder
         return new AstClassReference(
             ClassLikeName::fromFQCN($this->classLikeName),
             $this->inherits,
-            $this->dependencies
+            $this->dependencies,
+            $this->internal
         );
     }
 
@@ -185,6 +189,13 @@ final class ClassReferenceBuilder
             ClassLikeName::fromFQCN($classLikeName),
             FileOccurrence::fromFilepath($this->filepath, $occursAtLine)
         );
+
+        return $this;
+    }
+
+    public function markAsInternal(): self
+    {
+        $this->internal = true;
 
         return $this;
     }

--- a/src/AstRunner/Resolver/AnnotationDependencyResolver.php
+++ b/src/AstRunner/Resolver/AnnotationDependencyResolver.php
@@ -31,6 +31,20 @@ class AnnotationDependencyResolver implements ClassDependencyResolver
 
     public function processNode(Node $node, ClassReferenceBuilder $classReferenceBuilder, TypeScope $typeScope): void
     {
+        if ($node instanceof Node\Stmt\ClassLike) {
+            $docComment = $node->getDocComment();
+            if (!$docComment instanceof Doc) {
+                return;
+            }
+
+            $tokens = new TokenIterator($this->lexer->tokenize($docComment->getText()));
+            $docNode = $this->docParser->parse($tokens);
+
+            if (count($docNode->getTagsByName('@internal')) > 0) {
+                $classReferenceBuilder->markAsInternal();
+            }
+        }
+
         if (!$node instanceof Node\Stmt\Property
             && !$node instanceof Node\Expr\Variable
             && !$node instanceof Node\Stmt\ClassMethod

--- a/src/Collector/MarkedInternalCollector.php
+++ b/src/Collector/MarkedInternalCollector.php
@@ -11,7 +11,7 @@ class MarkedInternalCollector implements CollectorInterface
 {
     public function getType(): string
     {
-        return 'marked_internal';
+        return 'markedInternal';
     }
 
     public function satisfy(array $configuration, AstClassReference $astClassReference, AstMap $astMap, Registry $collectorRegistry): bool

--- a/src/Collector/MarkedInternalCollector.php
+++ b/src/Collector/MarkedInternalCollector.php
@@ -1,0 +1,21 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Qossmic\Deptrac\Collector;
+
+use Qossmic\Deptrac\AstRunner\AstMap;
+use Qossmic\Deptrac\AstRunner\AstMap\AstClassReference;
+
+class MarkedInternalCollector implements CollectorInterface
+{
+    public function getType(): string
+    {
+        return 'marked_internal';
+    }
+
+    public function satisfy(array $configuration, AstClassReference $astClassReference, AstMap $astMap, Registry $collectorRegistry): bool
+    {
+        return $astClassReference->isInternal();
+    }
+}

--- a/tests/AstRunner/Resolver/AnnotationDependencyResolverTest.php
+++ b/tests/AstRunner/Resolver/AnnotationDependencyResolverTest.php
@@ -38,7 +38,7 @@ final class AnnotationDependencyResolverTest extends TestCase
             $annotationDependency[0]->getClassLikeName()->toString()
         );
         self::assertSame($filePath, $annotationDependency[0]->getFileOccurrence()->getFilepath());
-        self::assertSame(9, $annotationDependency[0]->getFileOccurrence()->getLine());
+        self::assertSame(12, $annotationDependency[0]->getFileOccurrence()->getLine());
         self::assertSame('variable', $annotationDependency[0]->getType());
 
         self::assertSame(
@@ -46,7 +46,7 @@ final class AnnotationDependencyResolverTest extends TestCase
             $annotationDependency[1]->getClassLikeName()->toString()
         );
         self::assertSame($filePath, $annotationDependency[1]->getFileOccurrence()->getFilepath());
-        self::assertSame(23, $annotationDependency[1]->getFileOccurrence()->getLine());
+        self::assertSame(26, $annotationDependency[1]->getFileOccurrence()->getLine());
         self::assertSame('variable', $annotationDependency[1]->getType());
 
         self::assertSame(
@@ -54,7 +54,7 @@ final class AnnotationDependencyResolverTest extends TestCase
             $annotationDependency[2]->getClassLikeName()->toString()
         );
         self::assertSame($filePath, $annotationDependency[2]->getFileOccurrence()->getFilepath());
-        self::assertSame(26, $annotationDependency[2]->getFileOccurrence()->getLine());
+        self::assertSame(29, $annotationDependency[2]->getFileOccurrence()->getLine());
         self::assertSame('variable', $annotationDependency[2]->getType());
 
         self::assertSame(
@@ -62,7 +62,7 @@ final class AnnotationDependencyResolverTest extends TestCase
             $annotationDependency[3]->getClassLikeName()->toString()
         );
         self::assertSame($filePath, $annotationDependency[3]->getFileOccurrence()->getFilepath());
-        self::assertSame(29, $annotationDependency[3]->getFileOccurrence()->getLine());
+        self::assertSame(32, $annotationDependency[3]->getFileOccurrence()->getLine());
         self::assertSame('variable', $annotationDependency[3]->getType());
 
         self::assertSame(
@@ -70,7 +70,7 @@ final class AnnotationDependencyResolverTest extends TestCase
             $annotationDependency[4]->getClassLikeName()->toString()
         );
         self::assertSame($filePath, $annotationDependency[4]->getFileOccurrence()->getFilepath());
-        self::assertSame(14, $annotationDependency[4]->getFileOccurrence()->getLine());
+        self::assertSame(17, $annotationDependency[4]->getFileOccurrence()->getLine());
         self::assertSame('parameter', $annotationDependency[4]->getType());
 
         self::assertSame(
@@ -78,7 +78,10 @@ final class AnnotationDependencyResolverTest extends TestCase
             $annotationDependency[5]->getClassLikeName()->toString()
         );
         self::assertSame($filePath, $annotationDependency[5]->getFileOccurrence()->getFilepath());
-        self::assertSame(14, $annotationDependency[5]->getFileOccurrence()->getLine());
+        self::assertSame(17, $annotationDependency[5]->getFileOccurrence()->getLine());
         self::assertSame('returntype', $annotationDependency[5]->getType());
+
+        self::assertTrue($astClassReferences[0]->isInternal());
+        self::assertFalse($astClassReferences[1]->isInternal());
     }
 }

--- a/tests/AstRunner/Resolver/Fixtures/AnnotationDependency.php
+++ b/tests/AstRunner/Resolver/Fixtures/AnnotationDependency.php
@@ -4,6 +4,9 @@ declare(strict_types=1);
 
 namespace Tests\Qossmic\Deptrac\Integration\Fixtures;
 
+/**
+ * @internal
+ */
 final class AnnotationDependency
 {
     /**

--- a/tests/Collector/MarkedInternalCollectorTest.php
+++ b/tests/Collector/MarkedInternalCollectorTest.php
@@ -1,0 +1,44 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Qossmic\Deptrac\Collector;
+
+use PHPUnit\Framework\TestCase;
+use Qossmic\Deptrac\AstRunner\AstMap;
+use Qossmic\Deptrac\Collector\MarkedInternalCollector;
+
+final class MarkedInternalCollectorTest extends TestCase
+{
+    public function testGetType(): void
+    {
+        self::assertSame('marked_internal', (new MarkedInternalCollector())->getType());
+    }
+
+    public function testSatisfy(): void
+    {
+        $internalFooFileReferenceBuilder = AstMap\FileReferenceBuilder::create('internal_foo.php');
+        $internalFooFileReferenceBuilder
+            ->newClassLike('App\Internal\Foo')
+            ->markAsInternal();
+
+        $internalFooFileReference = $internalFooFileReferenceBuilder->build();
+
+        $classReferences = $internalFooFileReference->getAstClassReferences();
+
+        self::assertTrue($classReferences[0]->isInternal());
+    }
+
+    public function testDoesNotSatisfy(): void
+    {
+        $fooFileReferenceBuilder = AstMap\FileReferenceBuilder::create('foo.php');
+        $fooFileReferenceBuilder
+            ->newClassLike('App\Foo');
+
+        $fooFileReference = $fooFileReferenceBuilder->build();
+
+        $classReferences = $fooFileReference->getAstClassReferences();
+
+        self::assertFalse($classReferences[0]->isInternal());
+    }
+}

--- a/tests/Collector/MarkedInternalCollectorTest.php
+++ b/tests/Collector/MarkedInternalCollectorTest.php
@@ -12,7 +12,7 @@ final class MarkedInternalCollectorTest extends TestCase
 {
     public function testGetType(): void
     {
-        self::assertSame('marked_internal', (new MarkedInternalCollector())->getType());
+        self::assertSame('markedInternal', (new MarkedInternalCollector())->getType());
     }
 
     public function testSatisfy(): void


### PR DESCRIPTION
See #538 

To Do:

 * [x] Read `@internal` in class doc block
 * [x] Add flag to AstClassReference for `@internal`
 * [x] Provide collector for classes flagged as `@internal`