### PR TITLE
Add JSON formatter

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,6 +48,7 @@ this rule has been violated.
     1. [JUnit Formatter](#junit-formatter)
     1. [GitHubActions Formatter](#githubactions-formatter)
     1. [Baseline Formatter](#baseline-formatter)
+    1. [Json Formatter](#json-formatter)
 9. [Uncovered dependencies](#uncovered-dependencies)
 10. [Import depfiles](#import-depfiles)
 11. [Parameters](#parameters)
@@ -743,6 +744,66 @@ Include the baseline into your existing `depfile.yml`
 # depfile.yml
 baseline: depfile.baseline.yml
 ``` 
+
+### Json Formatter
+
+By default, Json formatter dumps information to *STDOUT*. It can be activated with `--formatter=json`
+
+```json
+{
+    "totals": {
+        "violations": 1,
+        "skipped": 2,
+        "uncovered": 1,
+        "allowed": 0,
+        "warnings": 0,
+        "errors": 0
+    },
+    "files": {
+        "src/ClassA.php": {
+            "errors": 2,
+            "messages": [
+                {
+                    "message": "ClassA must not depend on ClassB (LayerA on LayerB)",
+                    "line": 12,
+                    "type": "error"
+                },
+                {
+                    "message": "ClassA should not depend on ClassC (LayerA on LayerB)",
+                    "line": 15,
+                    "type": "warning"
+                }
+            ]
+        },
+        "src/ClassC.php": {
+            "errors": 1,
+            "messages": [
+                {
+                    "message": "ClassC should not depend on ClassD (LayerA on LayerB)",
+                    "line": 10,
+                    "type": "warning"
+                }
+            ]
+        },
+        "src/OriginalA.php": {
+            "errors": 1,
+            "messages": [
+                {
+                    "message": "OriginalA has uncovered dependency on OriginalB (LayerA)",
+                    "line": 5,
+                    "type": "warning"
+                }
+            ]
+        }
+    }
+}
+```
+
+Supported options:
+
+```
+--json-dump= path to a dumped json file
+```
 
 ## Uncovered dependencies
 

--- a/README.md
+++ b/README.md
@@ -751,17 +751,17 @@ By default, Json formatter dumps information to *STDOUT*. It can be activated wi
 
 ```json
 {
-    "totals": {
-        "violations": 1,
-        "skipped": 2,
-        "uncovered": 1,
-        "allowed": 0,
-        "warnings": 0,
-        "errors": 0
+    "Report": {
+        "Violations": 1,
+        "Skipped violations": 2,
+        "Uncovered": 1,
+        "Allowed": 0,
+        "Warnings": 0,
+        "Errors": 0
     },
     "files": {
         "src/ClassA.php": {
-            "errors": 2,
+            "violations": 2,
             "messages": [
                 {
                     "message": "ClassA must not depend on ClassB (LayerA on LayerB)",
@@ -776,7 +776,7 @@ By default, Json formatter dumps information to *STDOUT*. It can be activated wi
             ]
         },
         "src/ClassC.php": {
-            "errors": 1,
+            "violations": 1,
             "messages": [
                 {
                     "message": "ClassC should not depend on ClassD (LayerA on LayerB)",
@@ -786,7 +786,7 @@ By default, Json formatter dumps information to *STDOUT*. It can be activated wi
             ]
         },
         "src/OriginalA.php": {
-            "errors": 1,
+            "violations": 1,
             "messages": [
                 {
                     "message": "OriginalA has uncovered dependency on OriginalB (LayerA)",

--- a/config/services.php
+++ b/config/services.php
@@ -52,11 +52,11 @@ use Qossmic\Deptrac\OutputFormatter\XMLOutputFormatter;
 use Qossmic\Deptrac\OutputFormatterFactory;
 use Qossmic\Deptrac\RulesetEngine;
 use Symfony\Component\DependencyInjection\Loader\Configurator\ContainerConfigurator;
-use Symfony\Component\EventDispatcher\EventDispatcher;
 
 use function Symfony\Component\DependencyInjection\Loader\Configurator\param;
 use function Symfony\Component\DependencyInjection\Loader\Configurator\service;
 use function Symfony\Component\DependencyInjection\Loader\Configurator\tagged_iterator;
+use Symfony\Component\EventDispatcher\EventDispatcher;
 
 return static function (ContainerConfigurator $container): void {
     $services = $container->services();

--- a/config/services.php
+++ b/config/services.php
@@ -52,7 +52,6 @@ use Qossmic\Deptrac\OutputFormatter\XMLOutputFormatter;
 use Qossmic\Deptrac\OutputFormatterFactory;
 use Qossmic\Deptrac\RulesetEngine;
 use Symfony\Component\DependencyInjection\Loader\Configurator\ContainerConfigurator;
-
 use function Symfony\Component\DependencyInjection\Loader\Configurator\param;
 use function Symfony\Component\DependencyInjection\Loader\Configurator\service;
 use function Symfony\Component\DependencyInjection\Loader\Configurator\tagged_iterator;

--- a/config/services.php
+++ b/config/services.php
@@ -45,16 +45,18 @@ use Qossmic\Deptrac\OutputFormatter\BaselineOutputFormatter;
 use Qossmic\Deptrac\OutputFormatter\ConsoleOutputFormatter;
 use Qossmic\Deptrac\OutputFormatter\GithubActionsOutputFormatter;
 use Qossmic\Deptrac\OutputFormatter\GraphVizOutputFormatter;
+use Qossmic\Deptrac\OutputFormatter\JsonOutputFormatter;
 use Qossmic\Deptrac\OutputFormatter\JUnitOutputFormatter;
 use Qossmic\Deptrac\OutputFormatter\TableOutputFormatter;
 use Qossmic\Deptrac\OutputFormatter\XMLOutputFormatter;
 use Qossmic\Deptrac\OutputFormatterFactory;
 use Qossmic\Deptrac\RulesetEngine;
 use Symfony\Component\DependencyInjection\Loader\Configurator\ContainerConfigurator;
+use Symfony\Component\EventDispatcher\EventDispatcher;
+
 use function Symfony\Component\DependencyInjection\Loader\Configurator\param;
 use function Symfony\Component\DependencyInjection\Loader\Configurator\service;
 use function Symfony\Component\DependencyInjection\Loader\Configurator\tagged_iterator;
-use Symfony\Component\EventDispatcher\EventDispatcher;
 
 return static function (ContainerConfigurator $container): void {
     $services = $container->services();
@@ -171,6 +173,9 @@ return static function (ContainerConfigurator $container): void {
         ->tag('output_formatter');
     $services
         ->set(BaselineOutputFormatter::class)
+        ->tag('output_formatter');
+    $services
+        ->set(JsonOutputFormatter::class)
         ->tag('output_formatter');
 
     /* Collectors */

--- a/src/OutputFormatter/JsonOutputFormatter.php
+++ b/src/OutputFormatter/JsonOutputFormatter.php
@@ -1,0 +1,177 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Qossmic\Deptrac\OutputFormatter;
+
+use Qossmic\Deptrac\Console\Command\AnalyzeCommand;
+use Qossmic\Deptrac\Console\Output;
+use Qossmic\Deptrac\RulesetEngine\Context;
+use Qossmic\Deptrac\RulesetEngine\SkippedViolation;
+use Qossmic\Deptrac\RulesetEngine\Uncovered;
+use Qossmic\Deptrac\RulesetEngine\Violation;
+
+use function json_encode;
+
+final class JsonOutputFormatter implements OutputFormatterInterface
+{
+    public const DUMP_JSON = 'json-dump';
+
+    public function getName(): string
+    {
+        return 'json';
+    }
+
+    /**
+     * @return OutputFormatterOption[]
+     */
+    public function configureOptions(): array
+    {
+        return [
+            OutputFormatterOption::newValueOption(self::DUMP_JSON, 'path to a dumped json file'),
+        ];
+    }
+
+    public function enabledByDefault(): bool
+    {
+        return false;
+    }
+
+    /**
+     * {@inheritdoc}
+     *
+     * @throws \Exception
+     */
+    public function finish(
+        Context $context,
+        Output $output,
+        OutputFormatterInput $outputFormatterInput
+    ): void {
+        $reportSkipped   = $outputFormatterInput->getOptionAsBoolean(AnalyzeCommand::OPTION_REPORT_SKIPPED);
+        $reportUncovered = $outputFormatterInput->getOptionAsBoolean(AnalyzeCommand::OPTION_REPORT_UNCOVERED);
+
+        $jsonArray['files'] = [];
+        foreach ($context->rules() as $rule) {
+            if (! $rule instanceof Violation && ! $rule instanceof SkippedViolation && ! $rule instanceof Uncovered) {
+                continue;
+            }
+
+            if (! $reportSkipped && $rule instanceof SkippedViolation) {
+                continue;
+            }
+
+            if (! $reportUncovered && $rule instanceof Uncovered) {
+                continue;
+            }
+
+            switch (true) {
+                case $rule instanceof Violation:
+                    $this->addFailure($jsonArray['files'], $rule);
+                    break;
+                case $rule instanceof SkippedViolation:
+                    $this->addSkipped($jsonArray['files'], $rule);
+                    break;
+                case $rule instanceof Uncovered:
+                    $this->addUncovered($jsonArray['files'], $rule);
+                    break;
+            }
+        }
+
+        $jsonArray['totals'] = [
+            'violations' => count($context->violations()),
+            'skipped'    => count($context->skippedViolations()),
+            'uncovered'  => count($context->uncovered()),
+            'allowed'    => count($context->allowed()),
+            'warnings'   => count($context->warnings()),
+            'errors'     => count($context->errors()),
+        ];
+
+        $json = json_encode($jsonArray);
+
+        if ($dumpJsonPath = $outputFormatterInput->getOption(self::DUMP_JSON)) {
+            file_put_contents($dumpJsonPath, $json);
+            $output->writeLineFormatted('<info>JSON Report dumped to ' . realpath($dumpJsonPath) . '</info>');
+
+            return;
+        }
+
+        $output->writeRaw($json);
+    }
+
+    private function addFailure(array &$violationsArray, Violation $violation): void
+    {
+        $className = $violation->getDependency()->getFileOccurrence()->getFilepath();
+
+        $violationsArray[$className]['messages'][] = [
+            'message' => $this->getFailureMessage($violation),
+            'line'    => $violation->getDependency()->getFileOccurrence()->getLine(),
+            'type'    => 'error',
+        ];
+
+        $violationsArray[$className]['errors'] = count($violationsArray[$className]['messages']);
+    }
+
+    private function getFailureMessage(Violation $violation): string
+    {
+        $dependency = $violation->getDependency();
+
+        return sprintf(
+            '%s must not depend on %s (%s on %s)',
+            $dependency->getClassLikeNameA()->toString(),
+            $dependency->getClassLikeNameB()->toString(),
+            $violation->getLayerA(),
+            $violation->getLayerB()
+        );
+    }
+
+    private function addSkipped(array &$violationsArray, SkippedViolation $violation): void
+    {
+        $className = $violation->getDependency()->getFileOccurrence()->getFilepath();
+
+        $violationsArray[$className]['messages'][] = [
+            'message' => $this->getWarningMessage($violation),
+            'line'    => $violation->getDependency()->getFileOccurrence()->getLine(),
+            'type'    => 'warning',
+        ];
+
+        $violationsArray[$className]['errors'] = count($violationsArray[$className]['messages']);
+    }
+
+    private function getWarningMessage(SkippedViolation $violation): string
+    {
+        $dependency = $violation->getDependency();
+
+        return sprintf(
+            '%s should not depend on %s (%s on %s)',
+            $dependency->getClassLikeNameA()->toString(),
+            $dependency->getClassLikeNameB()->toString(),
+            $violation->getLayerA(),
+            $violation->getLayerB()
+        );
+    }
+
+    private function addUncovered(array &$violationsArray, Uncovered $violation)
+    {
+        $className = $violation->getDependency()->getFileOccurrence()->getFilepath();
+
+        $violationsArray[$className]['messages'][] = [
+            'message' => $this->getUncoveredMessage($violation),
+            'line'    => $violation->getDependency()->getFileOccurrence()->getLine(),
+            'type'    => 'warning',
+        ];
+
+        $violationsArray[$className]['errors'] = count($violationsArray[$className]['messages']);
+    }
+
+    private function getUncoveredMessage(Uncovered $violation)
+    {
+        $dependency = $violation->getDependency();
+
+        return sprintf(
+            '%s has uncovered dependency on %s (%s)',
+            $dependency->getClassLikeNameA()->toString(),
+            $dependency->getClassLikeNameB()->toString(),
+            $violation->getLayer()
+        );
+    }
+}

--- a/src/OutputFormatter/JsonOutputFormatter.php
+++ b/src/OutputFormatter/JsonOutputFormatter.php
@@ -4,14 +4,13 @@ declare(strict_types=1);
 
 namespace Qossmic\Deptrac\OutputFormatter;
 
+use function json_encode;
 use Qossmic\Deptrac\Console\Command\AnalyzeCommand;
 use Qossmic\Deptrac\Console\Output;
 use Qossmic\Deptrac\RulesetEngine\Context;
 use Qossmic\Deptrac\RulesetEngine\SkippedViolation;
 use Qossmic\Deptrac\RulesetEngine\Uncovered;
 use Qossmic\Deptrac\RulesetEngine\Violation;
-
-use function json_encode;
 
 final class JsonOutputFormatter implements OutputFormatterInterface
 {
@@ -47,20 +46,21 @@ final class JsonOutputFormatter implements OutputFormatterInterface
         Output $output,
         OutputFormatterInput $outputFormatterInput
     ): void {
-        $reportSkipped   = $outputFormatterInput->getOptionAsBoolean(AnalyzeCommand::OPTION_REPORT_SKIPPED);
+        $reportSkipped = $outputFormatterInput->getOptionAsBoolean(AnalyzeCommand::OPTION_REPORT_SKIPPED);
         $reportUncovered = $outputFormatterInput->getOptionAsBoolean(AnalyzeCommand::OPTION_REPORT_UNCOVERED);
 
+        $jsonArray = [];
         $jsonArray['files'] = [];
         foreach ($context->rules() as $rule) {
-            if (! $rule instanceof Violation && ! $rule instanceof SkippedViolation && ! $rule instanceof Uncovered) {
+            if (!$rule instanceof Violation && !$rule instanceof SkippedViolation && !$rule instanceof Uncovered) {
                 continue;
             }
 
-            if (! $reportSkipped && $rule instanceof SkippedViolation) {
+            if (!$reportSkipped && $rule instanceof SkippedViolation) {
                 continue;
             }
 
-            if (! $reportUncovered && $rule instanceof Uncovered) {
+            if (!$reportUncovered && $rule instanceof Uncovered) {
                 continue;
             }
 
@@ -77,38 +77,43 @@ final class JsonOutputFormatter implements OutputFormatterInterface
             }
         }
 
-        $jsonArray['totals'] = [
-            'violations' => count($context->violations()),
-            'skipped'    => count($context->skippedViolations()),
-            'uncovered'  => count($context->uncovered()),
-            'allowed'    => count($context->allowed()),
-            'warnings'   => count($context->warnings()),
-            'errors'     => count($context->errors()),
+        $jsonArray['Report'] = [
+            'Violations' => count($context->violations()),
+            'Skipped violations' => count($context->skippedViolations()),
+            'Uncovered' => count($context->uncovered()),
+            'Allowed' => count($context->allowed()),
+            'Warnings' => count($context->warnings()),
+            'Errors' => count($context->errors()),
         ];
 
         $json = json_encode($jsonArray);
 
-        if ($dumpJsonPath = $outputFormatterInput->getOption(self::DUMP_JSON)) {
+        $dumpJsonPath = (string) $outputFormatterInput->getOption(self::DUMP_JSON);
+        if ($dumpJsonPath) {
             file_put_contents($dumpJsonPath, $json);
-            $output->writeLineFormatted('<info>JSON Report dumped to ' . realpath($dumpJsonPath) . '</info>');
+            $output->writeLineFormatted('<info>JSON Report dumped to '.realpath($dumpJsonPath).'</info>');
 
             return;
         }
 
-        $output->writeRaw($json);
+        $output->writeRaw((string) $json);
     }
 
+    /**
+     * @param array<string, array<string, array<int, array<string, string|int>>>> $violationsArray
+     * @param-out non-empty-array<string, non-empty-array<string, 0|array<int, non-empty-array<string, int|string>>|positive-int>> $violationsArray
+     */
     private function addFailure(array &$violationsArray, Violation $violation): void
     {
         $className = $violation->getDependency()->getFileOccurrence()->getFilepath();
 
         $violationsArray[$className]['messages'][] = [
             'message' => $this->getFailureMessage($violation),
-            'line'    => $violation->getDependency()->getFileOccurrence()->getLine(),
-            'type'    => 'error',
+            'line' => $violation->getDependency()->getFileOccurrence()->getLine(),
+            'type' => 'error',
         ];
 
-        $violationsArray[$className]['errors'] = count($violationsArray[$className]['messages']);
+        $violationsArray[$className]['violations'] = count($violationsArray[$className]['messages']);
     }
 
     private function getFailureMessage(Violation $violation): string
@@ -124,17 +129,21 @@ final class JsonOutputFormatter implements OutputFormatterInterface
         );
     }
 
+    /**
+     * @param array<string, array<string, array<int, array<string, string|int>>>> $violationsArray
+     * @param-out non-empty-array<string, non-empty-array<string, 0|array<int, non-empty-array<string, int|string>>|positive-int>> $violationsArray
+     */
     private function addSkipped(array &$violationsArray, SkippedViolation $violation): void
     {
         $className = $violation->getDependency()->getFileOccurrence()->getFilepath();
 
         $violationsArray[$className]['messages'][] = [
             'message' => $this->getWarningMessage($violation),
-            'line'    => $violation->getDependency()->getFileOccurrence()->getLine(),
-            'type'    => 'warning',
+            'line' => $violation->getDependency()->getFileOccurrence()->getLine(),
+            'type' => 'warning',
         ];
 
-        $violationsArray[$className]['errors'] = count($violationsArray[$className]['messages']);
+        $violationsArray[$className]['violations'] = count($violationsArray[$className]['messages']);
     }
 
     private function getWarningMessage(SkippedViolation $violation): string
@@ -150,20 +159,24 @@ final class JsonOutputFormatter implements OutputFormatterInterface
         );
     }
 
-    private function addUncovered(array &$violationsArray, Uncovered $violation)
+    /**
+     * @param array<string, array<string, array<int, array<string, string|int>>>> $violationsArray
+     * @param-out non-empty-array<string, non-empty-array<string, 0|array<int, non-empty-array<string, int|string>>|positive-int>> $violationsArray
+     */
+    private function addUncovered(array &$violationsArray, Uncovered $violation): void
     {
         $className = $violation->getDependency()->getFileOccurrence()->getFilepath();
 
         $violationsArray[$className]['messages'][] = [
             'message' => $this->getUncoveredMessage($violation),
-            'line'    => $violation->getDependency()->getFileOccurrence()->getLine(),
-            'type'    => 'warning',
+            'line' => $violation->getDependency()->getFileOccurrence()->getLine(),
+            'type' => 'warning',
         ];
 
-        $violationsArray[$className]['errors'] = count($violationsArray[$className]['messages']);
+        $violationsArray[$className]['violations'] = count($violationsArray[$className]['messages']);
     }
 
-    private function getUncoveredMessage(Uncovered $violation)
+    private function getUncoveredMessage(Uncovered $violation): string
     {
         $dependency = $violation->getDependency();
 

--- a/src/OutputFormatter/JsonOutputFormatter.php
+++ b/src/OutputFormatter/JsonOutputFormatter.php
@@ -86,6 +86,10 @@ final class JsonOutputFormatter implements OutputFormatterInterface
             'Errors' => count($context->errors()),
         ];
 
+        foreach ($jsonArray['files'] as &$value) {
+            $value['violations'] = count($value['messages']);
+        }
+
         $json = json_encode($jsonArray);
 
         $dumpJsonPath = (string) $outputFormatterInput->getOption(self::DUMP_JSON);
@@ -112,8 +116,6 @@ final class JsonOutputFormatter implements OutputFormatterInterface
             'line' => $violation->getDependency()->getFileOccurrence()->getLine(),
             'type' => 'error',
         ];
-
-        $violationsArray[$className]['violations'] = count($violationsArray[$className]['messages']);
     }
 
     private function getFailureMessage(Violation $violation): string
@@ -142,8 +144,6 @@ final class JsonOutputFormatter implements OutputFormatterInterface
             'line' => $violation->getDependency()->getFileOccurrence()->getLine(),
             'type' => 'warning',
         ];
-
-        $violationsArray[$className]['violations'] = count($violationsArray[$className]['messages']);
     }
 
     private function getWarningMessage(SkippedViolation $violation): string
@@ -172,8 +172,6 @@ final class JsonOutputFormatter implements OutputFormatterInterface
             'line' => $violation->getDependency()->getFileOccurrence()->getLine(),
             'type' => 'warning',
         ];
-
-        $violationsArray[$className]['violations'] = count($violationsArray[$className]['messages']);
     }
 
     private function getUncoveredMessage(Uncovered $violation): string

--- a/src/OutputFormatter/JsonOutputFormatter.php
+++ b/src/OutputFormatter/JsonOutputFormatter.php
@@ -5,13 +5,13 @@ declare(strict_types=1);
 namespace Qossmic\Deptrac\OutputFormatter;
 
 use function json_encode;
+use function json_last_error;
 use Qossmic\Deptrac\Console\Command\AnalyzeCommand;
 use Qossmic\Deptrac\Console\Output;
 use Qossmic\Deptrac\RulesetEngine\Context;
 use Qossmic\Deptrac\RulesetEngine\SkippedViolation;
 use Qossmic\Deptrac\RulesetEngine\Uncovered;
 use Qossmic\Deptrac\RulesetEngine\Violation;
-use function json_last_error;
 use function sprintf;
 
 final class JsonOutputFormatter implements OutputFormatterInterface
@@ -95,7 +95,7 @@ final class JsonOutputFormatter implements OutputFormatterInterface
         $jsonArray['files'] = $violations;
         $json = json_encode($jsonArray, \JSON_PRETTY_PRINT);
 
-        if ($json === false) {
+        if (false === $json) {
             throw new \Exception(sprintf('Unable to render json output. %s', $this->jsonLastError()));
         }
 

--- a/src/OutputFormatter/JsonOutputFormatter.php
+++ b/src/OutputFormatter/JsonOutputFormatter.php
@@ -50,7 +50,7 @@ final class JsonOutputFormatter implements OutputFormatterInterface
         $reportUncovered = $outputFormatterInput->getOptionAsBoolean(AnalyzeCommand::OPTION_REPORT_UNCOVERED);
 
         $jsonArray = [];
-        $jsonArray['files'] = [];
+        $violations = [];
         foreach ($context->rules() as $rule) {
             if (!$rule instanceof Violation && !$rule instanceof SkippedViolation && !$rule instanceof Uncovered) {
                 continue;
@@ -66,13 +66,13 @@ final class JsonOutputFormatter implements OutputFormatterInterface
 
             switch (true) {
                 case $rule instanceof Violation:
-                    $this->addFailure($jsonArray['files'], $rule);
+                    $this->addFailure($violations, $rule);
                     break;
                 case $rule instanceof SkippedViolation:
-                    $this->addSkipped($jsonArray['files'], $rule);
+                    $this->addSkipped($violations, $rule);
                     break;
                 case $rule instanceof Uncovered:
-                    $this->addUncovered($jsonArray['files'], $rule);
+                    $this->addUncovered($violations, $rule);
                     break;
             }
         }
@@ -86,10 +86,11 @@ final class JsonOutputFormatter implements OutputFormatterInterface
             'Errors' => count($context->errors()),
         ];
 
-        foreach ($jsonArray['files'] as &$value) {
+        foreach ($violations as &$value) {
             $value['violations'] = count($value['messages']);
         }
 
+        $jsonArray['files'] = $violations;
         $json = json_encode($jsonArray);
 
         $dumpJsonPath = (string) $outputFormatterInput->getOption(self::DUMP_JSON);
@@ -104,8 +105,7 @@ final class JsonOutputFormatter implements OutputFormatterInterface
     }
 
     /**
-     * @param array<string, array<string, array<int, array<string, string|int>>>> $violationsArray
-     * @param-out non-empty-array<string, non-empty-array<string, 0|array<int, non-empty-array<string, int|string>>|positive-int>> $violationsArray
+     * @param array<string, array{messages: array<int, array{message: string, line: int, type: string}>}> $violationsArray
      */
     private function addFailure(array &$violationsArray, Violation $violation): void
     {
@@ -132,8 +132,7 @@ final class JsonOutputFormatter implements OutputFormatterInterface
     }
 
     /**
-     * @param array<string, array<string, array<int, array<string, string|int>>>> $violationsArray
-     * @param-out non-empty-array<string, non-empty-array<string, 0|array<int, non-empty-array<string, int|string>>|positive-int>> $violationsArray
+     * @param array<string, array{messages: array<int, array{message: string, line: int, type: string}>}> $violationsArray
      */
     private function addSkipped(array &$violationsArray, SkippedViolation $violation): void
     {
@@ -160,8 +159,7 @@ final class JsonOutputFormatter implements OutputFormatterInterface
     }
 
     /**
-     * @param array<string, array<string, array<int, array<string, string|int>>>> $violationsArray
-     * @param-out non-empty-array<string, non-empty-array<string, 0|array<int, non-empty-array<string, int|string>>|positive-int>> $violationsArray
+     * @param array<string, array{messages: array<int, array{message: string, line: int, type: string}>}> $violationsArray
      */
     private function addUncovered(array &$violationsArray, Uncovered $violation): void
     {

--- a/tests/LayerAnalyserTest.php
+++ b/tests/LayerAnalyserTest.php
@@ -36,12 +36,10 @@ class LayerAnalyserTest extends TestCase
         $analyser = $container->get(LayerAnalyser::class);
         $classLikes = $analyser->analyse($configuration, 'LayerFoo');
 
-        self::assertSame(
-            [
-                ClassBar::class,
-                ClassFoo::class,
-            ],
-            $classLikes
-        );
+        $expected = [
+            ClassBar::class,
+            ClassFoo::class,
+        ];
+        self::assertSame(sort($expected), sort($classLikes));
     }
 }

--- a/tests/LayerAnalyserTest.php
+++ b/tests/LayerAnalyserTest.php
@@ -36,10 +36,12 @@ class LayerAnalyserTest extends TestCase
         $analyser = $container->get(LayerAnalyser::class);
         $classLikes = $analyser->analyse($configuration, 'LayerFoo');
 
-        $expected = [
-            ClassBar::class,
-            ClassFoo::class,
-        ];
-        self::assertSame(sort($expected), sort($classLikes));
+        self::assertSame(
+            [
+                ClassBar::class,
+                ClassFoo::class,
+            ],
+            $classLikes
+        );
     }
 }

--- a/tests/OutputFormatter/JsonOutputFormatterTest.php
+++ b/tests/OutputFormatter/JsonOutputFormatterTest.php
@@ -1,0 +1,423 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Qossmic\Deptrac\OutputFormatter;
+
+use PHPUnit\Framework\TestCase;
+use Qossmic\Deptrac\AstRunner\AstMap\AstInherit;
+use Qossmic\Deptrac\AstRunner\AstMap\ClassLikeName;
+use Qossmic\Deptrac\AstRunner\AstMap\FileOccurrence;
+use Qossmic\Deptrac\Console\Command\AnalyzeCommand;
+use Qossmic\Deptrac\Console\Symfony\Style;
+use Qossmic\Deptrac\Console\Symfony\SymfonyOutput;
+use Qossmic\Deptrac\Dependency\Dependency;
+use Qossmic\Deptrac\Dependency\InheritDependency;
+use Qossmic\Deptrac\OutputFormatter\JsonOutputFormatter;
+use Qossmic\Deptrac\OutputFormatter\JUnitOutputFormatter;
+use Qossmic\Deptrac\OutputFormatter\OutputFormatterInput;
+use Qossmic\Deptrac\RulesetEngine\Context;
+use Qossmic\Deptrac\RulesetEngine\SkippedViolation;
+use Qossmic\Deptrac\RulesetEngine\Uncovered;
+use Qossmic\Deptrac\RulesetEngine\Violation;
+use Symfony\Component\Console\Input\InputInterface;
+use Symfony\Component\Console\Output\BufferedOutput;
+use Symfony\Component\Console\Style\SymfonyStyle;
+
+final class JsonOutputFormatterTest extends TestCase
+{
+    private static $actual_json_report_file = 'actual-deptrac-report.json';
+
+    public function tearDown(): void
+    {
+        if (file_exists(__DIR__ . '/data/' . self::$actual_json_report_file)) {
+            unlink(__DIR__ . '/data/' . self::$actual_json_report_file);
+        }
+    }
+
+    public function testGetName(): void
+    {
+        self::assertSame('json', (new JsonOutputFormatter())->getName());
+    }
+
+    public function basicDataProvider(): iterable
+    {
+        yield 'Multiple violations' => [
+            [
+                new Violation(
+                    new InheritDependency(
+                        ClassLikeName::fromFQCN('ClassA'),
+                        ClassLikeName::fromFQCN('ClassB'),
+                        new Dependency(
+                            ClassLikeName::fromFQCN('OriginalA'),
+                            ClassLikeName::fromFQCN('OriginalB'),
+                            FileOccurrence::fromFilepath('ClassA.php', 12)
+                        ),
+                        AstInherit::newExtends(
+                            ClassLikeName::fromFQCN('ClassInheritA'),
+                            FileOccurrence::fromFilepath('ClassA.php', 3)
+                        )->withPath(
+                            [
+                                AstInherit::newExtends(
+                                    ClassLikeName::fromFQCN('ClassInheritB'),
+                                    FileOccurrence::fromFilepath('ClassInheritA.php', 4)
+                                ),
+                                AstInherit::newExtends(
+                                    ClassLikeName::fromFQCN('ClassInheritC'),
+                                    FileOccurrence::fromFilepath('ClassInheritB.php', 5)
+                                ),
+                                AstInherit::newExtends(
+                                    ClassLikeName::fromFQCN('ClassInheritD'),
+                                    FileOccurrence::fromFilepath('ClassInheritC.php', 6)
+                                ),
+                            ]
+                        )
+                    ),
+                    'LayerA',
+                    'LayerB'
+                ),
+                new Violation(
+                    new InheritDependency(
+                        ClassLikeName::fromFQCN('ClassC'),
+                        ClassLikeName::fromFQCN('ClassD'),
+                        new Dependency(
+                            ClassLikeName::fromFQCN('OriginalA'),
+                            ClassLikeName::fromFQCN('OriginalB'),
+                            FileOccurrence::fromFilepath('ClassC.php', 12)
+                        ),
+                        AstInherit::newExtends(
+                            ClassLikeName::fromFQCN('ClassInheritA'),
+                            FileOccurrence::fromFilepath('ClassA.php', 3)
+                        )->withPath(
+                            [
+                                AstInherit::newExtends(
+                                    ClassLikeName::fromFQCN('ClassInheritB'),
+                                    FileOccurrence::fromFilepath('ClassInheritA.php', 4)
+                                ),
+                                AstInherit::newExtends(
+                                    ClassLikeName::fromFQCN('ClassInheritC'),
+                                    FileOccurrence::fromFilepath('ClassInheritB.php', 5)
+                                ),
+                                AstInherit::newExtends(
+                                    ClassLikeName::fromFQCN('ClassInheritD'),
+                                    FileOccurrence::fromFilepath('ClassInheritC.php', 6)
+                                ),
+                            ]
+                        )
+                    ),
+                    'LayerA',
+                    'LayerC'
+                ),
+                new Violation(
+                    new InheritDependency(
+                        ClassLikeName::fromFQCN('ClassC'),
+                        ClassLikeName::fromFQCN('ClassE'),
+                        new Dependency(
+                            ClassLikeName::fromFQCN('OriginalA'),
+                            ClassLikeName::fromFQCN('OriginalB'),
+                            FileOccurrence::fromFilepath('ClassC.php', 15)
+                        ),
+                        AstInherit::newExtends(
+                            ClassLikeName::fromFQCN('ClassInheritA'),
+                            FileOccurrence::fromFilepath('ClassA.php', 3)
+                        )->withPath(
+                            [
+                                AstInherit::newExtends(
+                                    ClassLikeName::fromFQCN('ClassInheritB'),
+                                    FileOccurrence::fromFilepath('ClassInheritA.php', 4)
+                                ),
+                                AstInherit::newExtends(
+                                    ClassLikeName::fromFQCN('ClassInheritC'),
+                                    FileOccurrence::fromFilepath('ClassInheritB.php', 5)
+                                ),
+                                AstInherit::newExtends(
+                                    ClassLikeName::fromFQCN('ClassInheritD'),
+                                    FileOccurrence::fromFilepath('ClassInheritC.php', 6)
+                                ),
+                            ]
+                        )
+                    ),
+                    'LayerA',
+                    'LayerE'
+                ),
+            ],
+            'expected-json-report_1.json',
+        ];
+
+        yield [
+            [
+                new Violation(
+                    new Dependency(
+                        ClassLikeName::fromFQCN('OriginalA'),
+                        ClassLikeName::fromFQCN('OriginalB'),
+                        FileOccurrence::fromFilepath('ClassA.php', 12)
+                    ),
+                    'LayerA',
+                    'LayerB'
+                ),
+            ],
+            'expected-json-report_2.json',
+        ];
+
+        yield [
+            [],
+            'expected-json-report_3.json',
+        ];
+
+        yield [
+            [
+                new SkippedViolation(
+                    new InheritDependency(
+                        ClassLikeName::fromFQCN('ClassA'),
+                        ClassLikeName::fromFQCN('ClassB'),
+                        new Dependency(
+                            ClassLikeName::fromFQCN('OriginalA'),
+                            ClassLikeName::fromFQCN('OriginalB'),
+                            FileOccurrence::fromFilepath('ClassA.php', 12)
+                        ),
+                        AstInherit::newExtends(
+                            ClassLikeName::fromFQCN('ClassInheritA'),
+                            FileOccurrence::fromFilepath('ClassA.php', 3)
+                        )->withPath(
+                            [
+                                AstInherit::newExtends(
+                                    ClassLikeName::fromFQCN('ClassInheritB'),
+                                    FileOccurrence::fromFilepath('ClassInheritA.php', 4)
+                                ),
+                                AstInherit::newExtends(
+                                    ClassLikeName::fromFQCN('ClassInheritC'),
+                                    FileOccurrence::fromFilepath('ClassInheritB.php', 5)
+                                ),
+                                AstInherit::newExtends(
+                                    ClassLikeName::fromFQCN('ClassInheritD'),
+                                    FileOccurrence::fromFilepath('ClassInheritC.php', 6)
+                                ),
+                            ]
+                        )
+                    ),
+                    'LayerA',
+                    'LayerB'
+                ),
+                new SkippedViolation(
+                    new InheritDependency(
+                        ClassLikeName::fromFQCN('ClassC'),
+                        ClassLikeName::fromFQCN('ClassD'),
+                        new Dependency(
+                            ClassLikeName::fromFQCN('OriginalA'),
+                            ClassLikeName::fromFQCN('OriginalB'),
+                            FileOccurrence::fromFilepath('ClassC.php', 12)
+                        ),
+                        AstInherit::newExtends(
+                            ClassLikeName::fromFQCN('ClassInheritA'),
+                            FileOccurrence::fromFilepath('ClassA.php', 3)
+                        )->withPath(
+                            [
+                                AstInherit::newExtends(
+                                    ClassLikeName::fromFQCN('ClassInheritB'),
+                                    FileOccurrence::fromFilepath('ClassInheritA.php', 4)
+                                ),
+                                AstInherit::newExtends(
+                                    ClassLikeName::fromFQCN('ClassInheritC'),
+                                    FileOccurrence::fromFilepath('ClassInheritB.php', 5)
+                                ),
+                                AstInherit::newExtends(
+                                    ClassLikeName::fromFQCN('ClassInheritD'),
+                                    FileOccurrence::fromFilepath('ClassInheritC.php', 6)
+                                ),
+                            ]
+                        )
+                    ),
+                    'LayerA',
+                    'LayerB'
+                ),
+            ],
+            'expected-json-report_4.json',
+            true,
+        ];
+
+        yield 'Different violations types in one report' => [
+            [
+                new Violation(
+                    new InheritDependency(
+                        ClassLikeName::fromFQCN('ClassA'),
+                        ClassLikeName::fromFQCN('ClassB'),
+                        new Dependency(
+                            ClassLikeName::fromFQCN('OriginalA'),
+                            ClassLikeName::fromFQCN('OriginalB'),
+                            FileOccurrence::fromFilepath('ClassA.php', 12)
+                        ),
+                        AstInherit::newExtends(
+                            ClassLikeName::fromFQCN('ClassInheritA'),
+                            FileOccurrence::fromFilepath('ClassA.php', 3)
+                        )->withPath(
+                            [
+                                AstInherit::newExtends(
+                                    ClassLikeName::fromFQCN('ClassInheritB'),
+                                    FileOccurrence::fromFilepath('ClassInheritA.php', 4)
+                                ),
+                                AstInherit::newExtends(
+                                    ClassLikeName::fromFQCN('ClassInheritC'),
+                                    FileOccurrence::fromFilepath('ClassInheritB.php', 5)
+                                ),
+                                AstInherit::newExtends(
+                                    ClassLikeName::fromFQCN('ClassInheritD'),
+                                    FileOccurrence::fromFilepath('ClassInheritC.php', 6)
+                                ),
+                            ]
+                        )
+                    ),
+                    'LayerA',
+                    'LayerB'
+                ),
+                new SkippedViolation(
+                    new InheritDependency(
+                        ClassLikeName::fromFQCN('ClassA'),
+                        ClassLikeName::fromFQCN('ClassB'),
+                        new Dependency(
+                            ClassLikeName::fromFQCN('OriginalA'),
+                            ClassLikeName::fromFQCN('OriginalB'),
+                            FileOccurrence::fromFilepath('ClassA.php', 15)
+                        ),
+                        AstInherit::newExtends(
+                            ClassLikeName::fromFQCN('ClassInheritA'),
+                            FileOccurrence::fromFilepath('ClassA.php', 3)
+                        )->withPath(
+                            [
+                                AstInherit::newExtends(
+                                    ClassLikeName::fromFQCN('ClassInheritB'),
+                                    FileOccurrence::fromFilepath('ClassInheritA.php', 4)
+                                ),
+                                AstInherit::newExtends(
+                                    ClassLikeName::fromFQCN('ClassInheritC'),
+                                    FileOccurrence::fromFilepath('ClassInheritB.php', 5)
+                                ),
+                                AstInherit::newExtends(
+                                    ClassLikeName::fromFQCN('ClassInheritD'),
+                                    FileOccurrence::fromFilepath('ClassInheritC.php', 6)
+                                ),
+                            ]
+                        )
+                    ),
+                    'LayerA',
+                    'LayerB'
+                ),
+                new SkippedViolation(
+                    new InheritDependency(
+                        ClassLikeName::fromFQCN('ClassC'),
+                        ClassLikeName::fromFQCN('ClassD'),
+                        new Dependency(
+                            ClassLikeName::fromFQCN('OriginalA'),
+                            ClassLikeName::fromFQCN('OriginalB'),
+                            FileOccurrence::fromFilepath('ClassC.php', 12)
+                        ),
+                        AstInherit::newExtends(
+                            ClassLikeName::fromFQCN('ClassInheritA'),
+                            FileOccurrence::fromFilepath('ClassA.php', 3)
+                        )->withPath(
+                            [
+                                AstInherit::newExtends(
+                                    ClassLikeName::fromFQCN('ClassInheritB'),
+                                    FileOccurrence::fromFilepath('ClassInheritA.php', 4)
+                                ),
+                                AstInherit::newExtends(
+                                    ClassLikeName::fromFQCN('ClassInheritC'),
+                                    FileOccurrence::fromFilepath('ClassInheritB.php', 5)
+                                ),
+                                AstInherit::newExtends(
+                                    ClassLikeName::fromFQCN('ClassInheritD'),
+                                    FileOccurrence::fromFilepath('ClassInheritC.php', 6)
+                                ),
+                            ]
+                        )
+                    ),
+                    'LayerA',
+                    'LayerB'
+                ),
+                new Uncovered(
+                    new Dependency(
+                        ClassLikeName::fromFQCN('OriginalA'),
+                        ClassLikeName::fromFQCN('OriginalB'),
+                        FileOccurrence::fromFilepath('OriginalA.php', 12)
+                    ),
+                    'LayerA'
+                ),
+            ],
+            'expected-json-report_5.json',
+            true,
+            true,
+        ];
+    }
+
+    /**
+     * @dataProvider basicDataProvider
+     */
+    public function testFileOutput(
+        array $rules,
+        $expectedOutputFile,
+        bool $reportSkipped = false,
+        bool $reportUncovered = false
+    ): void {
+        $bufferedOutput = new BufferedOutput();
+
+        $formatter = new JsonOutputFormatter();
+        $formatter->finish(
+            new Context($rules, [], []),
+            $this->createSymfonyOutput($bufferedOutput),
+            new OutputFormatterInput(
+                [
+                    AnalyzeCommand::OPTION_REPORT_UNCOVERED => $reportUncovered,
+                    AnalyzeCommand::OPTION_REPORT_SKIPPED   => $reportSkipped,
+                    JsonOutputFormatter::DUMP_JSON          => __DIR__ . '/data/' . self::$actual_json_report_file,
+                ]
+            )
+        );
+
+        self::assertJsonFileEqualsJsonFile(
+            __DIR__ . '/data/' . self::$actual_json_report_file,
+            __DIR__ . '/data/' . $expectedOutputFile
+        );
+    }
+
+    /**
+     * @dataProvider basicDataProvider
+     */
+    public function testConsoleOutput(
+        array $rules,
+        $expectedOutputFile,
+        bool $reportSkipped = false,
+        bool $reportUncovered = false
+    ): void {
+        $bufferedOutput = new BufferedOutput();
+
+        $formatter = new JsonOutputFormatter();
+        $formatter->finish(
+            new Context($rules, [], []),
+            $this->createSymfonyOutput($bufferedOutput),
+            new OutputFormatterInput(
+                [
+                    AnalyzeCommand::OPTION_REPORT_UNCOVERED => $reportUncovered,
+                    AnalyzeCommand::OPTION_REPORT_SKIPPED   => $reportSkipped,
+                    JsonOutputFormatter::DUMP_JSON          => null,
+                ]
+            )
+        );
+
+        self::assertJsonStringEqualsJsonFile(
+            __DIR__ . '/data/' . $expectedOutputFile,
+            $bufferedOutput->fetch()
+        );
+    }
+
+    public function testGetOptions(): void
+    {
+        self::assertCount(1, (new JUnitOutputFormatter())->configureOptions());
+    }
+
+    private function createSymfonyOutput(BufferedOutput $bufferedOutput): SymfonyOutput
+    {
+        return new SymfonyOutput(
+            $bufferedOutput,
+            new Style(new SymfonyStyle($this->createMock(InputInterface::class), $bufferedOutput))
+        );
+    }
+}

--- a/tests/OutputFormatter/JsonOutputFormatterTest.php
+++ b/tests/OutputFormatter/JsonOutputFormatterTest.php
@@ -30,8 +30,8 @@ final class JsonOutputFormatterTest extends TestCase
 
     public function tearDown(): void
     {
-        if (file_exists(__DIR__ . '/data/' . self::$actual_json_report_file)) {
-            unlink(__DIR__ . '/data/' . self::$actual_json_report_file);
+        if (file_exists(__DIR__.'/data/'.self::$actual_json_report_file)) {
+            unlink(__DIR__.'/data/'.self::$actual_json_report_file);
         }
     }
 
@@ -366,15 +366,15 @@ final class JsonOutputFormatterTest extends TestCase
             new OutputFormatterInput(
                 [
                     AnalyzeCommand::OPTION_REPORT_UNCOVERED => $reportUncovered,
-                    AnalyzeCommand::OPTION_REPORT_SKIPPED   => $reportSkipped,
-                    JsonOutputFormatter::DUMP_JSON          => __DIR__ . '/data/' . self::$actual_json_report_file,
+                    AnalyzeCommand::OPTION_REPORT_SKIPPED => $reportSkipped,
+                    JsonOutputFormatter::DUMP_JSON => __DIR__.'/data/'.self::$actual_json_report_file,
                 ]
             )
         );
 
         self::assertJsonFileEqualsJsonFile(
-            __DIR__ . '/data/' . self::$actual_json_report_file,
-            __DIR__ . '/data/' . $expectedOutputFile
+            __DIR__.'/data/'.self::$actual_json_report_file,
+            __DIR__.'/data/'.$expectedOutputFile
         );
     }
 
@@ -396,14 +396,14 @@ final class JsonOutputFormatterTest extends TestCase
             new OutputFormatterInput(
                 [
                     AnalyzeCommand::OPTION_REPORT_UNCOVERED => $reportUncovered,
-                    AnalyzeCommand::OPTION_REPORT_SKIPPED   => $reportSkipped,
-                    JsonOutputFormatter::DUMP_JSON          => null,
+                    AnalyzeCommand::OPTION_REPORT_SKIPPED => $reportSkipped,
+                    JsonOutputFormatter::DUMP_JSON => null,
                 ]
             )
         );
 
         self::assertJsonStringEqualsJsonFile(
-            __DIR__ . '/data/' . $expectedOutputFile,
+            __DIR__.'/data/'.$expectedOutputFile,
             $bufferedOutput->fetch()
         );
     }

--- a/tests/OutputFormatter/data/expected-json-report_1.json
+++ b/tests/OutputFormatter/data/expected-json-report_1.json
@@ -1,15 +1,15 @@
 {
-    "totals": {
-        "violations": 3,
-        "skipped": 0,
-        "uncovered": 0,
-        "allowed": 0,
-        "warnings": 0,
-        "errors": 0
+    "Report": {
+        "Violations": 3,
+        "Skipped violations": 0,
+        "Uncovered": 0,
+        "Allowed": 0,
+        "Warnings": 0,
+        "Errors": 0
     },
     "files": {
         "ClassA.php": {
-            "errors": 1,
+            "violations": 1,
             "messages": [
                 {
                     "message": "ClassA must not depend on ClassB (LayerA on LayerB)",
@@ -19,7 +19,7 @@
             ]
         },
         "ClassC.php": {
-            "errors": 2,
+            "violations": 2,
             "messages": [
                 {
                     "message": "ClassC must not depend on ClassD (LayerA on LayerC)",

--- a/tests/OutputFormatter/data/expected-json-report_1.json
+++ b/tests/OutputFormatter/data/expected-json-report_1.json
@@ -1,0 +1,37 @@
+{
+    "totals": {
+        "violations": 3,
+        "skipped": 0,
+        "uncovered": 0,
+        "allowed": 0,
+        "warnings": 0,
+        "errors": 0
+    },
+    "files": {
+        "ClassA.php": {
+            "errors": 1,
+            "messages": [
+                {
+                    "message": "ClassA must not depend on ClassB (LayerA on LayerB)",
+                    "line": 12,
+                    "type": "error"
+                }
+            ]
+        },
+        "ClassC.php": {
+            "errors": 2,
+            "messages": [
+                {
+                    "message": "ClassC must not depend on ClassD (LayerA on LayerC)",
+                    "line": 12,
+                    "type": "error"
+                },
+                {
+                    "message": "ClassC must not depend on ClassE (LayerA on LayerE)",
+                    "line": 15,
+                    "type": "error"
+                }
+            ]
+        }
+    }
+}

--- a/tests/OutputFormatter/data/expected-json-report_2.json
+++ b/tests/OutputFormatter/data/expected-json-report_2.json
@@ -1,15 +1,15 @@
 {
-    "totals": {
-        "violations": 1,
-        "skipped": 0,
-        "uncovered": 0,
-        "allowed": 0,
-        "warnings": 0,
-        "errors": 0
+    "Report": {
+        "Violations": 1,
+        "Skipped violations": 0,
+        "Uncovered": 0,
+        "Allowed": 0,
+        "Warnings": 0,
+        "Errors": 0
     },
     "files": {
         "ClassA.php": {
-            "errors": 1,
+            "violations": 1,
             "messages": [
                 {
                     "message": "OriginalA must not depend on OriginalB (LayerA on LayerB)",

--- a/tests/OutputFormatter/data/expected-json-report_2.json
+++ b/tests/OutputFormatter/data/expected-json-report_2.json
@@ -1,0 +1,22 @@
+{
+    "totals": {
+        "violations": 1,
+        "skipped": 0,
+        "uncovered": 0,
+        "allowed": 0,
+        "warnings": 0,
+        "errors": 0
+    },
+    "files": {
+        "ClassA.php": {
+            "errors": 1,
+            "messages": [
+                {
+                    "message": "OriginalA must not depend on OriginalB (LayerA on LayerB)",
+                    "line": 12,
+                    "type": "error"
+                }
+            ]
+        }
+    }
+}

--- a/tests/OutputFormatter/data/expected-json-report_3.json
+++ b/tests/OutputFormatter/data/expected-json-report_3.json
@@ -1,0 +1,11 @@
+{
+    "totals": {
+        "violations": 0,
+        "skipped": 0,
+        "uncovered": 0,
+        "allowed": 0,
+        "warnings": 0,
+        "errors": 0
+    },
+    "files": []
+}

--- a/tests/OutputFormatter/data/expected-json-report_3.json
+++ b/tests/OutputFormatter/data/expected-json-report_3.json
@@ -1,11 +1,11 @@
 {
-    "totals": {
-        "violations": 0,
-        "skipped": 0,
-        "uncovered": 0,
-        "allowed": 0,
-        "warnings": 0,
-        "errors": 0
+    "Report": {
+        "Violations": 0,
+        "Skipped violations": 0,
+        "Uncovered": 0,
+        "Allowed": 0,
+        "Warnings": 0,
+        "Errors": 0
     },
     "files": []
 }

--- a/tests/OutputFormatter/data/expected-json-report_4.json
+++ b/tests/OutputFormatter/data/expected-json-report_4.json
@@ -1,15 +1,15 @@
 {
-    "totals": {
-        "violations": 0,
-        "skipped": 2,
-        "uncovered": 0,
-        "allowed": 0,
-        "warnings": 0,
-        "errors": 0
+    "Report": {
+        "Violations": 0,
+        "Skipped violations": 2,
+        "Uncovered": 0,
+        "Allowed": 0,
+        "Warnings": 0,
+        "Errors": 0
     },
     "files": {
         "ClassA.php": {
-            "errors": 1,
+            "violations": 1,
             "messages": [
                 {
                     "message": "ClassA should not depend on ClassB (LayerA on LayerB)",
@@ -19,7 +19,7 @@
             ]
         },
         "ClassC.php": {
-            "errors": 1,
+            "violations": 1,
             "messages": [
                 {
                     "message": "ClassC should not depend on ClassD (LayerA on LayerB)",

--- a/tests/OutputFormatter/data/expected-json-report_4.json
+++ b/tests/OutputFormatter/data/expected-json-report_4.json
@@ -1,0 +1,32 @@
+{
+    "totals": {
+        "violations": 0,
+        "skipped": 2,
+        "uncovered": 0,
+        "allowed": 0,
+        "warnings": 0,
+        "errors": 0
+    },
+    "files": {
+        "ClassA.php": {
+            "errors": 1,
+            "messages": [
+                {
+                    "message": "ClassA should not depend on ClassB (LayerA on LayerB)",
+                    "line": 12,
+                    "type": "warning"
+                }
+            ]
+        },
+        "ClassC.php": {
+            "errors": 1,
+            "messages": [
+                {
+                    "message": "ClassC should not depend on ClassD (LayerA on LayerB)",
+                    "line": 12,
+                    "type": "warning"
+                }
+            ]
+        }
+    }
+}

--- a/tests/OutputFormatter/data/expected-json-report_5.json
+++ b/tests/OutputFormatter/data/expected-json-report_5.json
@@ -1,15 +1,15 @@
 {
-    "totals": {
-        "violations": 1,
-        "skipped": 2,
-        "uncovered": 1,
-        "allowed": 0,
-        "warnings": 0,
-        "errors": 0
+    "Report": {
+        "Violations": 1,
+        "Skipped violations": 2,
+        "Uncovered": 1,
+        "Allowed": 0,
+        "Warnings": 0,
+        "Errors": 0
     },
     "files": {
         "ClassA.php": {
-            "errors": 2,
+            "violations": 2,
             "messages": [
                 {
                     "message": "ClassA must not depend on ClassB (LayerA on LayerB)",
@@ -24,7 +24,7 @@
             ]
         },
         "ClassC.php": {
-            "errors": 1,
+            "violations": 1,
             "messages": [
                 {
                     "message": "ClassC should not depend on ClassD (LayerA on LayerB)",
@@ -34,7 +34,7 @@
             ]
         },
         "OriginalA.php": {
-            "errors": 1,
+            "violations": 1,
             "messages": [
                 {
                     "message": "OriginalA has uncovered dependency on OriginalB (LayerA)",

--- a/tests/OutputFormatter/data/expected-json-report_5.json
+++ b/tests/OutputFormatter/data/expected-json-report_5.json
@@ -1,0 +1,47 @@
+{
+    "totals": {
+        "violations": 1,
+        "skipped": 2,
+        "uncovered": 1,
+        "allowed": 0,
+        "warnings": 0,
+        "errors": 0
+    },
+    "files": {
+        "ClassA.php": {
+            "errors": 2,
+            "messages": [
+                {
+                    "message": "ClassA must not depend on ClassB (LayerA on LayerB)",
+                    "line": 12,
+                    "type": "error"
+                },
+                {
+                    "message": "ClassA should not depend on ClassB (LayerA on LayerB)",
+                    "line": 15,
+                    "type": "warning"
+                }
+            ]
+        },
+        "ClassC.php": {
+            "errors": 1,
+            "messages": [
+                {
+                    "message": "ClassC should not depend on ClassD (LayerA on LayerB)",
+                    "line": 12,
+                    "type": "warning"
+                }
+            ]
+        },
+        "OriginalA.php": {
+            "errors": 1,
+            "messages": [
+                {
+                    "message": "OriginalA has uncovered dependency on OriginalB (LayerA)",
+                    "line": 12,
+                    "type": "warning"
+                }
+            ]
+        }
+    }
+}


### PR DESCRIPTION
Added json formatter. 
By default, formatter dumps information to STDOUT, so you can use command line tools to handle it.
Optionally we can use flag `--json-dump=<path>` to dumps information in file.

Output format is close to [PHP_CodeSniffer](https://github.com/squizlabs/PHP_CodeSniffer/wiki/Reporting#printing-a-json-report) or [PhpStan](https://github.com/phpstan/phpstan/commit/2f5b724d2da978b8cf24a133fb04ba9e2171571c) formats.