### PR TITLE
JUnit output formatter - unmatched skipped violations

### DIFF
--- a/src/OutputFormatter/JUnitOutputFormatter.php
+++ b/src/OutputFormatter/JUnitOutputFormatter.php
@@ -89,7 +89,7 @@ final class JUnitOutputFormatter implements OutputFormatterInterface
             $testSuite->appendChild(new \DOMAttr('errors', (string) count($context->errors())));
             $testSuite->appendChild(new \DOMAttr('time', '0'));
             foreach ($context->errors() as $message) {
-                $error = $xmlDoc->createElement('failure');
+                $error = $xmlDoc->createElement('error');
                 $error->appendChild(new \DOMAttr('message', $message->toString()));
                 $error->appendChild(new \DOMAttr('type', 'WARNING'));
                 $testSuite->appendChild($error);

--- a/src/OutputFormatter/JUnitOutputFormatter.php
+++ b/src/OutputFormatter/JUnitOutputFormatter.php
@@ -77,6 +77,27 @@ final class JUnitOutputFormatter implements OutputFormatterInterface
 
         $xmlDoc->appendChild($testSuites);
 
+        if ($context->hasErrors()) {
+            $testSuite = $xmlDoc->createElement('testsuite');
+            $testSuite->appendChild(new \DOMAttr('id', '0'));
+            $testSuite->appendChild(new \DOMAttr('package', ''));
+            $testSuite->appendChild(new \DOMAttr('name', 'Unmatched skipped violations'));
+            $testSuite->appendChild(new \DOMAttr('hostname', 'localhost'));
+            $testSuite->appendChild(new \DOMAttr('tests', '0'));
+            $testSuite->appendChild(new \DOMAttr('failures', '0'));
+            $testSuite->appendChild(new \DOMAttr('skipped', '0'));
+            $testSuite->appendChild(new \DOMAttr('errors', (string) count($context->errors())));
+            $testSuite->appendChild(new \DOMAttr('time', '0'));
+            foreach ($context->errors() as $message) {
+                $error = $xmlDoc->createElement('failure');
+                $error->appendChild(new \DOMAttr('message', $message->toString()));
+                $error->appendChild(new \DOMAttr('type', 'WARNING'));
+                $testSuite->appendChild($error);
+            }
+
+            $testSuites->appendChild($testSuite);
+        }
+
         $this->addTestSuite($context, $xmlDoc, $testSuites);
     }
 

--- a/tests/OutputFormatter/JUnitOutputFormatterTest.php
+++ b/tests/OutputFormatter/JUnitOutputFormatterTest.php
@@ -152,8 +152,8 @@ final class JUnitOutputFormatterTest extends TestCase
             ], []),
             $this->createSymfonyOutput(new BufferedOutput()),
             new OutputFormatterInput([
-                                         JUnitOutputFormatter::DUMP_XML => __DIR__.'/data/'.self::$actual_junit_report_file,
-                                     ])
+                JUnitOutputFormatter::DUMP_XML => __DIR__.'/data/'.self::$actual_junit_report_file,
+            ])
         );
 
         self::assertXmlFileEqualsXmlFile(

--- a/tests/OutputFormatter/JUnitOutputFormatterTest.php
+++ b/tests/OutputFormatter/JUnitOutputFormatterTest.php
@@ -15,6 +15,7 @@ use Qossmic\Deptrac\Dependency\InheritDependency;
 use Qossmic\Deptrac\OutputFormatter\JUnitOutputFormatter;
 use Qossmic\Deptrac\OutputFormatter\OutputFormatterInput;
 use Qossmic\Deptrac\RulesetEngine\Context;
+use Qossmic\Deptrac\RulesetEngine\Error;
 use Qossmic\Deptrac\RulesetEngine\SkippedViolation;
 use Qossmic\Deptrac\RulesetEngine\Violation;
 use Symfony\Component\Console\Input\InputInterface;
@@ -140,6 +141,25 @@ final class JUnitOutputFormatterTest extends TestCase
     public function testGetOptions(): void
     {
         self::assertCount(1, (new JUnitOutputFormatter())->configureOptions());
+    }
+
+    public function testUnmatchedSkipped(): void
+    {
+        $formatter = new JUnitOutputFormatter();
+        $formatter->finish(
+            new Context([], [
+                new Error('Skipped violation "Class1" for "Class2" was not matched.'),
+            ], []),
+            $this->createSymfonyOutput(new BufferedOutput()),
+            new OutputFormatterInput([
+                                         JUnitOutputFormatter::DUMP_XML => __DIR__.'/data/'.self::$actual_junit_report_file,
+                                     ])
+        );
+
+        self::assertXmlFileEqualsXmlFile(
+            __DIR__.'/data/'.self::$actual_junit_report_file,
+            __DIR__.'/data/expected-junit-report-with-unmatched-violations.xml'
+        );
     }
 
     private function createSymfonyOutput(BufferedOutput $bufferedOutput): SymfonyOutput

--- a/tests/OutputFormatter/data/expected-junit-report-with-unmatched-violations.xml
+++ b/tests/OutputFormatter/data/expected-junit-report-with-unmatched-violations.xml
@@ -1,0 +1,6 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<testsuites>
+    <testsuite id="0" package="" name="Unmatched skipped violations" hostname="localhost" tests="0" failures="0" skipped="0" errors="1" time="0">
+        <error message="Skipped violation &quot;Class1&quot; for &quot;Class2&quot; was not matched." type="WARNING"/>
+    </testsuite>
+</testsuites>


### PR DESCRIPTION
Closes #568

Adding this (sample) output at the beginning of the file.
```xml
<?xml version="1.0" encoding="UTF-8"?>
<testsuites>
  <testsuite id="0" package="" name="Unmatched skipped violations" hostname="localhost" tests="0" failures="0" skipped="0" errors="4" time="0">
    <failure message="Skipped violation &quot;TrainingCompass\Saas\Dashboards\Controls\Dashboard\LayoutControl&quot; for &quot;TrainingCompass\Saas\Branding\Personal\DashboardPresenter&quot; was not matched." type="WARNING"/>
    <failure message="Skipped violation &quot;TrainingCompass\Saas\Dashboards\Controls\Dashboard\LayoutControlFactory&quot; for &quot;TrainingCompass\Saas\Branding\Personal\DashboardPresenter&quot; was not matched." type="WARNING"/>
    <failure message="Skipped violation &quot;TrainingCompass\Saas\Dashboards\Controls\DashboardLayoutConfig\LayoutConfigControl&quot; for &quot;TrainingCompass\Saas\Branding\Personal\ProfilePresenter&quot; was not matched." type="WARNING"/>
    <failure message="Skipped violation &quot;TrainingCompass\Saas\Dashboards\Controls\DashboardLayoutConfig\LayoutConfigControlFactory&quot; for &quot;TrainingCompass\Saas\Branding\Personal\ProfilePresenter&quot; was not matched." type="WARNING"/>
  </testsuite>
