### PR TITLE
Basic template type and generic support

### DIFF
--- a/src/AstRunner/AstMap/ClassReferenceBuilder.php
+++ b/src/AstRunner/AstMap/ClassReferenceBuilder.php
@@ -21,6 +21,9 @@ final class ClassReferenceBuilder
     /** @var string[] */
     private $classTemplates;
 
+    /**
+     * @param string[] $classTemplates
+     */
     private function __construct(string $filepath, string $classLikeName, array $classTemplates)
     {
         $this->filepath = $filepath;

--- a/src/AstRunner/AstMap/ClassReferenceBuilder.php
+++ b/src/AstRunner/AstMap/ClassReferenceBuilder.php
@@ -18,15 +18,22 @@ final class ClassReferenceBuilder
     /** @var AstDependency[] */
     private $dependencies = [];
 
-    private function __construct(string $filepath, string $classLikeName)
+    /** @var string[] */
+    private $classTemplates;
+
+    private function __construct(string $filepath, string $classLikeName, array $classTemplates)
     {
         $this->filepath = $filepath;
         $this->classLikeName = $classLikeName;
+        $this->classTemplates = $classTemplates;
     }
 
-    public static function create(string $filepath, string $classLikeName): self
+    /**
+     * @param string[] $classTemplates
+     */
+    public static function create(string $filepath, string $classLikeName, array $classTemplates): self
     {
-        return new self($filepath, $classLikeName);
+        return new self($filepath, $classLikeName, $classTemplates);
     }
 
     /** @internal */
@@ -197,5 +204,13 @@ final class ClassReferenceBuilder
         );
 
         return $this;
+    }
+
+    /**
+     * @return string[]
+     */
+    public function getClassTemplates(): array
+    {
+        return $this->classTemplates;
     }
 }

--- a/src/AstRunner/AstMap/FileReferenceBuilder.php
+++ b/src/AstRunner/AstMap/FileReferenceBuilder.php
@@ -45,9 +45,12 @@ final class FileReferenceBuilder
         return $this;
     }
 
-    public function newClassLike(string $classLikeName): ClassReferenceBuilder
+    /**
+     * @param string[] $templateTypes
+     */
+    public function newClassLike(string $classLikeName, array $templateTypes = []): ClassReferenceBuilder
     {
-        $this->classReferences[] = $this->currentClassReference = ClassReferenceBuilder::create($this->filepath, $classLikeName);
+        $this->classReferences[] = $this->currentClassReference = ClassReferenceBuilder::create($this->filepath, $classLikeName, $templateTypes);
 
         return $this->currentClassReference;
     }

--- a/src/AstRunner/Resolver/AnnotationDependencyResolver.php
+++ b/src/AstRunner/Resolver/AnnotationDependencyResolver.php
@@ -46,11 +46,11 @@ class AnnotationDependencyResolver implements ClassDependencyResolver
 
         $tokens = new TokenIterator($this->lexer->tokenize($docComment->getText()));
         $docNode = $this->docParser->parse($tokens);
-        $templateTypes = array_map(
+        $templateTypes = array_merge(array_map(
             static function (TemplateTagValueNode $node): string {
                 return $node->name;
             },
-            $docNode->getTemplateTagValues());
+            $docNode->getTemplateTagValues()), $classReferenceBuilder->getClassTemplates());
 
         foreach ($docNode->getParamTagValues() as $tag) {
             $types = $this->typeResolver->resolvePHPStanDocParserType($tag->type, $typeScope, $templateTypes);

--- a/tests/AstRunner/Resolver/AnnotationDependencyResolverTest.php
+++ b/tests/AstRunner/Resolver/AnnotationDependencyResolverTest.php
@@ -31,7 +31,7 @@ final class AnnotationDependencyResolverTest extends TestCase
         $annotationDependency = $astClassReferences[0]->getDependencies();
 
         self::assertCount(2, $astClassReferences);
-        self::assertCount(7, $annotationDependency);
+        self::assertCount(9, $annotationDependency);
         self::assertCount(0, $astClassReferences[1]->getDependencies());
 
         self::assertSame(

--- a/tests/AstRunner/Resolver/Fixtures/AnnotationDependency.php
+++ b/tests/AstRunner/Resolver/Fixtures/AnnotationDependency.php
@@ -34,7 +34,7 @@ final class AnnotationDependency
 
     /**
      * @template T
-     * @param T as mixed
+     * @param T $var
      * @return AnnotationDependencyChild<T>
      */
     public function template($var)
@@ -48,7 +48,18 @@ final class AnnotationDependency
  */
 final class AnnotationDependencyChild
 {
+    /**
+     * @param T $var
+     */
     public function __construct($var)
     {
+    }
+
+    /**
+     * @return T
+     */
+    public function get()
+    {
+
     }
 }

--- a/tests/AstRunner/Resolver/Fixtures/AnnotationDependency.php
+++ b/tests/AstRunner/Resolver/Fixtures/AnnotationDependency.php
@@ -31,8 +31,24 @@ final class AnnotationDependency
 
         return [];
     }
+
+    /**
+     * @template T
+     * @param T as mixed
+     * @return AnnotationDependencyChild<T>
+     */
+    public function template($var)
+    {
+        return new AnnotationDependencyChild($var);
+    }
 }
 
+/**
+ * @template T
+ */
 final class AnnotationDependencyChild
 {
+    public function __construct($var)
+    {
+    }
 }

--- a/tests/AstRunner/Resolver/TypeResolverTest.php
+++ b/tests/AstRunner/Resolver/TypeResolverTest.php
@@ -41,7 +41,7 @@ final class TypeResolverTest extends TestCase
         $typeNode = $this->typeParser->parse($tokens);
 
         $typeResolver = new TypeResolver();
-        $resolvedTypes = $typeResolver->resolvePHPStanDocParserType($typeNode, new TypeScope('\\Test\\'));
+        $resolvedTypes = $typeResolver->resolvePHPStanDocParserType($typeNode, new TypeScope('\\Test\\'), ['T']);
 
         self::assertSame($types, $resolvedTypes);
     }
@@ -60,5 +60,9 @@ final class TypeResolverTest extends TestCase
         yield ['doc' => 'positive-int', 'types' => []];
         yield ['doc' => 'non-empty-array<string>', 'types' => []];
         yield ['doc' => 'callable-array', 'types' => []];
+        yield ['doc' => 'list<Foo>', 'types' => ['\\Test\\Foo']];
+        yield ['doc' => 'T', 'types' => []];
+        yield ['doc' => 'Foo<T>', 'types' => ['\\Test\\Foo']];
+        yield ['doc' => 'T<Foo>', 'types' => ['\\Test\\Foo']];
     }
 }

--- a/tests/AstRunner/Resolver/TypeResolverTest.php
+++ b/tests/AstRunner/Resolver/TypeResolverTest.php
@@ -64,5 +64,6 @@ final class TypeResolverTest extends TestCase
         yield ['doc' => 'T', 'types' => []];
         yield ['doc' => 'Foo<T>', 'types' => ['\\Test\\Foo']];
         yield ['doc' => 'T<Foo>', 'types' => ['\\Test\\Foo']];
+        yield ['doc' => 'Bar<Foo>', 'types' => ['\\Test\\Bar', '\\Test\\Foo']];
     }
 }


### PR DESCRIPTION
Closes #535
It is far from complete support, but it extends current support for generics and `@template` annotation
What is in:
 - Method template types (but the template type it should be resolved to is ignored)
  - list generic (`list<*>`)
  - resolving "pre-generic type" `resolved<*>`
  - template type on class resolved recognized in method
  
 What is still missing:
  - resolving the template type