### PR TITLE
Add example for transitive dependencies.

### DIFF
--- a/examples/Transitive.depfile.yaml
+++ b/examples/Transitive.depfile.yaml
@@ -1,0 +1,27 @@
+paths: ["./Transitive"]
+exclude_files: []
+layers:
+  - name: Foo
+    collectors:
+      - type: className
+        regex: .*\\Foo$
+  - name: Baz
+    collectors:
+      - type: className
+        regex: .*\\Baz$
+  - name: Bar
+    collectors:
+      - type: className
+        regex: .*\\Bar$
+  - name: Bat
+    collectors:
+      - type: className
+        regex: .*\\Bat$
+ruleset:
+  Foo:
+    - Bar
+  Bar: ~
+  Baz:
+    - +Foo
+  Bat:
+    - Foo

--- a/examples/Transitive/Bar.php
+++ b/examples/Transitive/Bar.php
@@ -1,0 +1,7 @@
+<?php
+
+namespace examples\Transitive;
+
+class Bar
+{
+}

--- a/examples/Transitive/Bat.php
+++ b/examples/Transitive/Bat.php
@@ -1,0 +1,10 @@
+<?php
+
+namespace examples\Transitive;
+
+class Bat
+{
+    public function __construct(Foo $foo, Bar $bar)
+    {
+    }
+}

--- a/examples/Transitive/Baz.php
+++ b/examples/Transitive/Baz.php
@@ -1,0 +1,10 @@
+<?php
+
+namespace examples\Transitive;
+
+class Baz
+{
+    public function __construct(Foo $foo, Bar $bar)
+    {
+    }
+}

--- a/examples/Transitive/Foo.php
+++ b/examples/Transitive/Foo.php
@@ -1,0 +1,10 @@
+<?php
+
+namespace examples\Transitive;
+
+class Foo
+{
+    public function __construct(Bar $bar)
+    {
+    }
+}


### PR DESCRIPTION
Examples act as e2e during build. I tried this on 0.14.0 to confirm the issue as well as the current main to verify the fix.

Follow up to #618