### PR TITLE
Ruleset-Engine-without-Configuration-dependency

### DIFF
--- a/src/Analyser.php
+++ b/src/Analyser.php
@@ -35,6 +35,6 @@ class Analyser
         $dependencyResult = $this->resolver->resolve($astMap);
         $classLikeLayerResolver = $this->classLikeLayerResolverFactory->create($configuration, $astMap);
 
-        return $this->rulesetEngine->process($dependencyResult, $classLikeLayerResolver, $configuration);
+        return $this->rulesetEngine->process($dependencyResult, $classLikeLayerResolver, $configuration->getRuleset());
     }
 }

--- a/src/Configuration/Configuration.php
+++ b/src/Configuration/Configuration.php
@@ -92,11 +92,12 @@ class Configuration
             throw InvalidConfigurationException::fromUnknownLayerNames(...$unknownLayerNames);
         }
 
-        $options['ruleset']['skip_violations'] = $options['skip_violations'];
-        $options['ruleset']['ignore_uncovered_internal_classes'] = $options['ignore_uncovered_internal_classes'];
-
         $this->parameters = $options['parameters'];
-        $this->ruleset = ConfigurationRuleset::fromArray($options['ruleset']);
+        $this->ruleset = ConfigurationRuleset::fromOptions(
+            $options['ruleset'],
+            ConfigurationSkippedViolation::fromArray($options['skip_violations'] ?? []),
+            (bool)($options['ignore_uncovered_internal_classes'] ?? false)
+        );
         $this->paths = $options['paths'];
         $this->excludeFiles = (array) $options['exclude_files'];
         $this->formatters = (array) $options['formatters'];

--- a/src/Configuration/Configuration.php
+++ b/src/Configuration/Configuration.php
@@ -16,8 +16,6 @@ class Configuration
     /** @var string[] */
     private array $excludeFiles;
     private ConfigurationRuleset $ruleset;
-    private ConfigurationSkippedViolation $skipViolations;
-    private bool $ignoreUncoveredInternalClasses;
     /** @var array<string, string> */
     private array $parameters;
     private ConfigurationAnalyzer $analyzer;
@@ -94,12 +92,13 @@ class Configuration
             throw InvalidConfigurationException::fromUnknownLayerNames(...$unknownLayerNames);
         }
 
+        $options['ruleset']['skip_violations'] = $options['skip_violations'];
+        $options['ruleset']['ignore_uncovered_internal_classes'] = $options['ignore_uncovered_internal_classes'];
+
         $this->parameters = $options['parameters'];
         $this->ruleset = ConfigurationRuleset::fromArray($options['ruleset']);
         $this->paths = $options['paths'];
-        $this->skipViolations = ConfigurationSkippedViolation::fromArray($options['skip_violations']);
         $this->excludeFiles = (array) $options['exclude_files'];
-        $this->ignoreUncoveredInternalClasses = (bool) $options['ignore_uncovered_internal_classes'];
         $this->formatters = (array) $options['formatters'];
         $this->analyzer = ConfigurationAnalyzer::fromArray($options['analyzer']);
     }
@@ -131,16 +130,6 @@ class Configuration
     public function getRuleset(): ConfigurationRuleset
     {
         return $this->ruleset;
-    }
-
-    public function getSkipViolations(): ConfigurationSkippedViolation
-    {
-        return $this->skipViolations;
-    }
-
-    public function ignoreUncoveredInternalClasses(): bool
-    {
-        return $this->ignoreUncoveredInternalClasses;
     }
 
     /**

--- a/src/Configuration/ConfigurationRuleset.php
+++ b/src/Configuration/ConfigurationRuleset.php
@@ -17,20 +17,30 @@ final class ConfigurationRuleset
 
     /**
      * @param array<string, string[]> $arr
+     * @param ConfigurationSkippedViolation $skippedViolation
+     * @param bool $ignoreUncoveredInternalClasses
      */
-    public static function fromArray(array $arr): self
-    {
-        return new self($arr);
+    public static function fromOptions(
+        array $arr,
+        ConfigurationSkippedViolation $skippedViolation,
+        bool $ignoreUncoveredInternalClasses
+    ): self {
+        return new self($arr, $skippedViolation, $ignoreUncoveredInternalClasses);
     }
 
     /**
      * @param array<string, string[]> $layerMap
+     * @param ConfigurationSkippedViolation $skippedViolation
+     * @param bool $ignoreUncoveredInternalClasses
      */
-    private function __construct(array $layerMap)
-    {
+    private function __construct(
+        array $layerMap,
+        ConfigurationSkippedViolation $skippedViolation,
+        bool $ignoreUncoveredInternalClasses
+    ) {
         $this->layerMap = $layerMap;
-        $this->skipViolations = ConfigurationSkippedViolation::fromArray($layerMap['skip_violations'] ?? []);
-        $this->ignoreUncoveredInternalClasses = (bool)($layerMap['ignore_uncovered_internal_classes'] ?? false);
+        $this->skipViolations = $skippedViolation;
+        $this->ignoreUncoveredInternalClasses = $ignoreUncoveredInternalClasses;
     }
 
     /**

--- a/src/Configuration/ConfigurationRuleset.php
+++ b/src/Configuration/ConfigurationRuleset.php
@@ -11,6 +11,10 @@ final class ConfigurationRuleset
     /** @var array<string, string[]> */
     private array $layerMap;
 
+    private ConfigurationSkippedViolation $skipViolations;
+
+    private bool $ignoreUncoveredInternalClasses;
+
     /**
      * @param array<string, string[]> $arr
      */
@@ -25,6 +29,8 @@ final class ConfigurationRuleset
     private function __construct(array $layerMap)
     {
         $this->layerMap = $layerMap;
+        $this->skipViolations = ConfigurationSkippedViolation::fromArray($layerMap['skip_violations'] ?? []);
+        $this->ignoreUncoveredInternalClasses = (bool)($layerMap['ignore_uncovered_internal_classes'] ?? false);
     }
 
     /**
@@ -35,6 +41,16 @@ final class ConfigurationRuleset
     public function getAllowedDependencies(string $layerName): array
     {
         return array_values(array_unique($this->getTransitiveDependencies($layerName, [])));
+    }
+
+    public function getSkipViolations(): ConfigurationSkippedViolation
+    {
+        return $this->skipViolations;
+    }
+
+    public function ignoreUncoveredInternalClasses(): bool
+    {
+        return $this->ignoreUncoveredInternalClasses;
     }
 
     /**

--- a/src/RulesetEngine.php
+++ b/src/RulesetEngine.php
@@ -7,7 +7,7 @@ namespace Qossmic\Deptrac;
 use InvalidArgumentException;
 use JetBrains\PHPStormStub\PhpStormStubsMap;
 use Qossmic\Deptrac\AstRunner\AstMap\ClassLikeName;
-use Qossmic\Deptrac\Configuration\Configuration;
+use Qossmic\Deptrac\Configuration\ConfigurationRuleset;
 use Qossmic\Deptrac\Dependency\Result;
 use Qossmic\Deptrac\RulesetEngine\Allowed;
 use Qossmic\Deptrac\RulesetEngine\Context;
@@ -23,14 +23,13 @@ class RulesetEngine
     public function process(
         Result $dependencyResult,
         ClassLikeLayerResolverInterface $classLikeLayerResolver,
-        Configuration $configuration
+        ConfigurationRuleset $configurationRuleset
     ): Context {
         $rules = [];
         $warnings = [];
         $errors = [];
 
-        $configurationRuleset = $configuration->getRuleset();
-        $skippedViolationHelper = new SkippedViolationHelper($configuration->getSkipViolations());
+        $skippedViolationHelper = new SkippedViolationHelper($configurationRuleset->getSkipViolations());
 
         foreach ($dependencyResult->getDependenciesAndInheritDependencies() as $dependency) {
             $layerNames = $classLikeLayerResolver->getLayersByClassLikeName($dependency->getClassLikeNameA());
@@ -51,7 +50,7 @@ class RulesetEngine
                 $layersNamesClassB = $classLikeLayerResolver->getLayersByClassLikeName($dependency->getClassLikeNameB());
 
                 if (0 === count($layersNamesClassB)) {
-                    if (!$this->ignoreUncoveredInternalClass($configuration, $dependency->getClassLikeNameB())) {
+                    if (!$this->ignoreUncoveredInternalClass($configurationRuleset, $dependency->getClassLikeNameB())) {
                         $rules[] = new Uncovered($dependency, $layerName);
                     }
                     continue;
@@ -86,8 +85,8 @@ class RulesetEngine
         return new Context($rules, $errors, $warnings);
     }
 
-    private function ignoreUncoveredInternalClass(Configuration $configuration, ClassLikeName $classLikeName): bool
+    private function ignoreUncoveredInternalClass(ConfigurationRuleset $configurationRuleset, ClassLikeName $classLikeName): bool
     {
-        return $configuration->ignoreUncoveredInternalClasses() && isset(PhpStormStubsMap::CLASSES[$classLikeName->toString()]);
+        return $configurationRuleset->ignoreUncoveredInternalClasses() && isset(PhpStormStubsMap::CLASSES[$classLikeName->toString()]);
     }
 }

--- a/tests/Configuration/ConfigurationRulesetTest.php
+++ b/tests/Configuration/ConfigurationRulesetTest.php
@@ -46,4 +46,32 @@ final class ConfigurationRulesetTest extends TestCase
         $this->expectException(\InvalidArgumentException::class);
         $configurationRuleSet->getAllowedDependencies('a');
     }
+
+    public function testSkipViolations(): void
+    {
+        $configuration = ConfigurationRuleset::fromArray([
+            'skip_violations' => [
+                'FooClass' => [
+                    'BarClass',
+                    'AnotherClass',
+                ],
+            ],
+        ]);
+
+        self::assertSame([
+            'FooClass' => [
+                'BarClass',
+                'AnotherClass',
+            ],
+        ], $configuration->getSkipViolations()->all());
+    }
+
+    public function testIgnoreUncoveredInternalClassesSetToFalse(): void
+    {
+        $configuration = ConfigurationRuleset::fromArray([
+            'ignore_uncovered_internal_classes' => false,
+        ]);
+
+        self::assertFalse($configuration->ignoreUncoveredInternalClasses());
+    }
 }

--- a/tests/Configuration/ConfigurationTest.php
+++ b/tests/Configuration/ConfigurationTest.php
@@ -128,7 +128,7 @@ final class ConfigurationTest extends TestCase
         self::assertEquals(['foo', 'bar'], $configuration->getPaths());
         self::assertEquals(['foo2', 'bar2'], $configuration->getExcludeFiles());
         self::assertEquals(['xx', 'yy'], $configuration->getRuleset()->getAllowedDependencies('some_name'));
-        self::assertTrue($configuration->ignoreUncoveredInternalClasses());
+        self::assertTrue($configuration->getRuleset()->ignoreUncoveredInternalClasses());
     }
 
     public function testExcludedFilesAreOptional(): void
@@ -166,40 +166,5 @@ final class ConfigurationTest extends TestCase
         ]);
 
         self::assertEquals([], $configuration->getExcludeFiles());
-    }
-
-    public function testSkipViolations(): void
-    {
-        $configuration = Configuration::fromArray([
-            'layers' => [],
-            'paths' => [],
-            'exclude_files' => null,
-            'ruleset' => [],
-            'skip_violations' => [
-                'FooClass' => [
-                    'BarClass',
-                    'AnotherClass',
-                ],
-            ],
-        ]);
-
-        self::assertSame([
-            'FooClass' => [
-                'BarClass',
-                'AnotherClass',
-            ],
-        ], $configuration->getSkipViolations()->all());
-    }
-
-    public function testIgnoreUncoveredInternalClassesSetToFalse(): void
-    {
-        $configuration = Configuration::fromArray([
-            'layers' => [],
-            'paths' => [],
-            'ruleset' => [],
-            'ignore_uncovered_internal_classes' => false,
-        ]);
-
-        self::assertFalse($configuration->ignoreUncoveredInternalClasses());
     }
 }

--- a/tests/Configuration/LoaderTest.php
+++ b/tests/Configuration/LoaderTest.php
@@ -74,7 +74,7 @@ final class LoaderTest extends TestCase
                     'BarClass',
                 ],
             ],
-            $configuration->getSkipViolations()->all()
+            $configuration->getRuleset()->getSkipViolations()->all()
         );
     }
 

--- a/tests/RulesetEngineTest.php
+++ b/tests/RulesetEngineTest.php
@@ -248,7 +248,7 @@ final class RulesetEngineTest extends TestCase
         $context = (new RulesetEngine())->process(
             $dependencyResult,
             $classLikeLayerResolver->reveal(),
-            $configuration
+            $configuration->getRuleset()
         );
 
         self::assertCount($expectedCount, $context->violations());
@@ -316,7 +316,7 @@ final class RulesetEngineTest extends TestCase
         $context = (new RulesetEngine())->process(
             $dependencyResult,
             $classLikeLayerResolver->reveal(),
-            $configuration
+            $configuration->getRuleset()
         );
 
         self::assertCount($expectedSkippedViolationCount, $context->skippedViolations());
@@ -371,7 +371,7 @@ final class RulesetEngineTest extends TestCase
         $context = (new RulesetEngine())->process(
             $dependencyResult,
             $classLikeLayerResolver->reveal(),
-            $configuration
+            $configuration->getRuleset()
         );
 
         self::assertCount($expectedUncoveredCount, $context->uncovered());


### PR DESCRIPTION
Using `ConfigurationRuleset` instead of `Configuration`