### PR TITLE
Make library usable as is without shim

### DIFF
--- a/deptrac.php
+++ b/deptrac.php
@@ -9,10 +9,6 @@ if (PHP_VERSION_ID < 70400) {
 }
 
 (static function (): void {
-    require_once __DIR__.'/vendor/autoload.php';
-})();
-
-(static function (): void {
     if (\file_exists($autoload = getcwd().'/vendor/autoload.php')) {
         include_once $autoload;
     }

--- a/deptrac.php
+++ b/deptrac.php
@@ -9,6 +9,12 @@ if (PHP_VERSION_ID < 70400) {
 }
 
 (static function (): void {
+    if (\file_exists($autoload = __DIR__.'/vendor/autoload.php')) {
+        require_once $autoload;
+    }
+})();
+
+(static function (): void {
     if (\file_exists($autoload = getcwd().'/vendor/autoload.php')) {
         include_once $autoload;
     }


### PR DESCRIPTION
Installing vias shim is great and all, but there are reasons why one might now want to do so. From the top of my head:
 - Not wanting to wait for a release. You might pin to a commit instead and get new features before a tagged release
 - It is a strong precursor for writing extensions to the package.