### PR TITLE
[WIP] Add ClassMethodResolver to determine return types by Method returns

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -20,7 +20,7 @@
         "php": "^7.4.0 || 8.0.* || 8.1.*",
         "ext-json": "*",
         "composer/xdebug-handler": "^2.0",
-        "jetbrains/phpstorm-stubs": "^2020.2",
+        "jetbrains/phpstorm-stubs": "^v2019.3",
         "nikic/php-parser": "^4.3",
         "phpdocumentor/graphviz": "^2.0",
         "phpdocumentor/type-resolver": "^1.0",
@@ -31,7 +31,8 @@
         "symfony/event-dispatcher": "^5.1",
         "symfony/finder": "^5.1",
         "symfony/options-resolver": "^5.1",
-        "symfony/yaml": "^5.1"
+        "symfony/yaml": "^5.1",
+        "roave/better-reflection": "^4.12.0"
     },
     "suggest": {
         "ext-dom": "For using the JUnit output formatter"

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "8457cc3651c7dda1cf502b69a9aecd56",
+    "content-hash": "ea43c4e9c7b45916b5602d9703a38266",
     "packages": [
         {
             "name": "composer/xdebug-handler",
@@ -72,24 +72,23 @@
         },
         {
             "name": "jetbrains/phpstorm-stubs",
-            "version": "v2020.3",
+            "version": "v2019.3",
             "source": {
                 "type": "git",
                 "url": "https://github.com/JetBrains/phpstorm-stubs.git",
-                "reference": "daf8849db40acded37b13231a291c7536922955b"
+                "reference": "883b6facd78e01c0743b554af86fa590c2573f40"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/JetBrains/phpstorm-stubs/zipball/daf8849db40acded37b13231a291c7536922955b",
-                "reference": "daf8849db40acded37b13231a291c7536922955b",
+                "url": "https://api.github.com/repos/JetBrains/phpstorm-stubs/zipball/883b6facd78e01c0743b554af86fa590c2573f40",
+                "reference": "883b6facd78e01c0743b554af86fa590c2573f40",
                 "shasum": ""
             },
             "require-dev": {
-                "friendsofphp/php-cs-fixer": "^2.16",
-                "nikic/php-parser": "dev-master",
-                "php": "^8.0",
-                "phpdocumentor/reflection-docblock": "dev-master",
-                "phpunit/phpunit": "^9"
+                "nikic/php-parser": "^4",
+                "php": "^7.1",
+                "phpdocumentor/reflection-docblock": "^4.3",
+                "phpunit/phpunit": "^7"
             },
             "type": "library",
             "autoload": {
@@ -114,9 +113,9 @@
                 "type"
             ],
             "support": {
-                "source": "https://github.com/JetBrains/phpstorm-stubs/tree/v2020.3"
+                "source": "https://github.com/JetBrains/phpstorm-stubs/tree/master"
             },
-            "time": "2020-11-24T13:58:53+00:00"
+            "time": "2019-12-05T16:56:26+00:00"
         },
         {
             "name": "nikic/php-parser",
@@ -278,6 +277,62 @@
                 "source": "https://github.com/phpDocumentor/ReflectionCommon/tree/2.x"
             },
             "time": "2020-06-27T09:03:43+00:00"
+        },
+        {
+            "name": "phpdocumentor/reflection-docblock",
+            "version": "5.2.2",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/phpDocumentor/ReflectionDocBlock.git",
+                "reference": "069a785b2141f5bcf49f3e353548dc1cce6df556"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/phpDocumentor/ReflectionDocBlock/zipball/069a785b2141f5bcf49f3e353548dc1cce6df556",
+                "reference": "069a785b2141f5bcf49f3e353548dc1cce6df556",
+                "shasum": ""
+            },
+            "require": {
+                "ext-filter": "*",
+                "php": "^7.2 || ^8.0",
+                "phpdocumentor/reflection-common": "^2.2",
+                "phpdocumentor/type-resolver": "^1.3",
+                "webmozart/assert": "^1.9.1"
+            },
+            "require-dev": {
+                "mockery/mockery": "~1.3.2"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "5.x-dev"
+                }
+            },
+            "autoload": {
+                "psr-4": {
+                    "phpDocumentor\\Reflection\\": "src"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Mike van Riel",
+                    "email": "me@mikevanriel.com"
+                },
+                {
+                    "name": "Jaap van Otterdijk",
+                    "email": "account@ijaap.nl"
+                }
+            ],
+            "description": "With this component, a library can provide support for annotations via DocBlocks or otherwise retrieve information that is embedded in a DocBlock.",
+            "support": {
+                "issues": "https://github.com/phpDocumentor/ReflectionDocBlock/issues",
+                "source": "https://github.com/phpDocumentor/ReflectionDocBlock/tree/master"
+            },
+            "time": "2020-09-03T19:13:55+00:00"
         },
         {
             "name": "phpdocumentor/type-resolver",
@@ -524,6 +579,124 @@
                 "source": "https://github.com/php-fig/log/tree/1.1.4"
             },
             "time": "2021-05-03T11:20:27+00:00"
+        },
+        {
+            "name": "roave/better-reflection",
+            "version": "4.12.2",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/Roave/BetterReflection.git",
+                "reference": "73c376c7245b2928837ed1e8bef446f57f1148a0"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/Roave/BetterReflection/zipball/73c376c7245b2928837ed1e8bef446f57f1148a0",
+                "reference": "73c376c7245b2928837ed1e8bef446f57f1148a0",
+                "shasum": ""
+            },
+            "require": {
+                "ext-json": "*",
+                "jetbrains/phpstorm-stubs": "2019.3",
+                "nikic/php-parser": "^4.6.0",
+                "php": ">=7.4.1,<7.5.0",
+                "phpdocumentor/reflection-docblock": "^5.2.2",
+                "phpdocumentor/type-resolver": "^1.4.0",
+                "roave/signature": "^1.3"
+            },
+            "require-dev": {
+                "doctrine/coding-standard": "^8.2.0",
+                "infection/infection": "^0.20.0",
+                "phpstan/phpstan": "0.12.25",
+                "phpunit/phpunit": "^9.4.4",
+                "roave/infection-static-analysis-plugin": "^1.2",
+                "vimeo/psalm": "^4.2"
+            },
+            "suggest": {
+                "composer/composer": "Required to use the ComposerSourceLocator"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "4.0-dev"
+                }
+            },
+            "autoload": {
+                "psr-4": {
+                    "Roave\\BetterReflection\\": "src"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "James Titcumb",
+                    "email": "james@asgrim.com",
+                    "homepage": "https://github.com/asgrim"
+                },
+                {
+                    "name": "Marco Pivetta",
+                    "email": "ocramius@gmail.com",
+                    "homepage": "https://ocramius.github.io/"
+                },
+                {
+                    "name": "Gary Hockin",
+                    "email": "gary@roave.com",
+                    "homepage": "https://github.com/geeh"
+                },
+                {
+                    "name": "Jaroslav Hanslík",
+                    "email": "kukulich@kukulich.cz",
+                    "homepage": "https://github.com/kukulich"
+                }
+            ],
+            "description": "Better Reflection - an improved code reflection API",
+            "support": {
+                "issues": "https://github.com/Roave/BetterReflection/issues",
+                "source": "https://github.com/Roave/BetterReflection/tree/4.12.2"
+            },
+            "time": "2020-12-17T17:48:54+00:00"
+        },
+        {
+            "name": "roave/signature",
+            "version": "1.4.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/Roave/Signature.git",
+                "reference": "5b5bb9499cfbcc78d9f472e03af1e97e4341ec7c"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/Roave/Signature/zipball/5b5bb9499cfbcc78d9f472e03af1e97e4341ec7c",
+                "reference": "5b5bb9499cfbcc78d9f472e03af1e97e4341ec7c",
+                "shasum": ""
+            },
+            "require": {
+                "php": "7.4.*|8.0.*"
+            },
+            "require-dev": {
+                "doctrine/coding-standard": "^8.2",
+                "infection/infection": "^0.20.2",
+                "phpunit/phpunit": "^9.5.1",
+                "vimeo/psalm": "^4.4"
+            },
+            "type": "library",
+            "autoload": {
+                "psr-4": {
+                    "Roave\\Signature\\": "src"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "description": "Sign and verify stuff",
+            "support": {
+                "issues": "https://github.com/Roave/Signature/issues",
+                "source": "https://github.com/Roave/Signature/tree/1.4.0"
+            },
+            "time": "2021-01-25T09:39:37+00:00"
         },
         {
             "name": "symfony/config",
@@ -2017,6 +2190,64 @@
                 }
             ],
             "time": "2021-07-29T06:20:01+00:00"
+        },
+        {
+            "name": "webmozart/assert",
+            "version": "1.10.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/webmozarts/assert.git",
+                "reference": "6964c76c7804814a842473e0c8fd15bab0f18e25"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/webmozarts/assert/zipball/6964c76c7804814a842473e0c8fd15bab0f18e25",
+                "reference": "6964c76c7804814a842473e0c8fd15bab0f18e25",
+                "shasum": ""
+            },
+            "require": {
+                "php": "^7.2 || ^8.0",
+                "symfony/polyfill-ctype": "^1.8"
+            },
+            "conflict": {
+                "phpstan/phpstan": "<0.12.20",
+                "vimeo/psalm": "<4.6.1 || 4.6.2"
+            },
+            "require-dev": {
+                "phpunit/phpunit": "^8.5.13"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "1.10-dev"
+                }
+            },
+            "autoload": {
+                "psr-4": {
+                    "Webmozart\\Assert\\": "src/"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Bernhard Schussek",
+                    "email": "bschussek@gmail.com"
+                }
+            ],
+            "description": "Assertions to validate method input/output with nice error messages.",
+            "keywords": [
+                "assert",
+                "check",
+                "validate"
+            ],
+            "support": {
+                "issues": "https://github.com/webmozarts/assert/issues",
+                "source": "https://github.com/webmozarts/assert/tree/1.10.0"
+            },
+            "time": "2021-03-09T10:59:23+00:00"
         }
     ],
     "packages-dev": [],

--- a/config/services.php
+++ b/config/services.php
@@ -12,6 +12,7 @@ use Qossmic\Deptrac\AstRunner\AstRunner;
 use Qossmic\Deptrac\AstRunner\Resolver\AnnotationDependencyResolver;
 use Qossmic\Deptrac\AstRunner\Resolver\AnonymousClassResolver;
 use Qossmic\Deptrac\AstRunner\Resolver\ClassConstantResolver;
+use Qossmic\Deptrac\AstRunner\Resolver\ClassMethodResolver;
 use Qossmic\Deptrac\AstRunner\Resolver\TypeResolver;
 use Qossmic\Deptrac\Collector\BoolCollector;
 use Qossmic\Deptrac\Collector\ClassNameCollector;
@@ -58,6 +59,7 @@ use Qossmic\Deptrac\RulesetEngine;
 use Qossmic\Deptrac\TokenAnalyser;
 use Qossmic\Deptrac\TokenLayerResolverFactory;
 use Qossmic\Deptrac\UnassignedAnalyser;
+use Roave\BetterReflection\BetterReflection;
 use Symfony\Component\DependencyInjection\Loader\Configurator\ContainerConfigurator;
 use function Symfony\Component\DependencyInjection\Loader\Configurator\param;
 use function Symfony\Component\DependencyInjection\Loader\Configurator\service;
@@ -94,6 +96,7 @@ return static function (ContainerConfigurator $container): void {
             service(AnnotationDependencyResolver::class),
             service(AnonymousClassResolver::class),
             service(ClassConstantResolver::class),
+            service(ClassMethodResolver::class),
         ]);
 
     $services
@@ -101,7 +104,14 @@ return static function (ContainerConfigurator $container): void {
         ->args([service(TypeResolver::class)]);
     $services->set(AnonymousClassResolver::class);
     $services->set(ClassConstantResolver::class);
+    $services->set(ClassMethodResolver::class)
+        ->args([
+            service(TypeResolver::class),
+            service(BetterReflection::class)
+        ]);
     $services->set(TypeResolver::class);
+    $services->set(BetterReflection::class);
+
 
     $services
         ->set(TokenLayerResolverFactory::class)

--- a/src/AstRunner/AstMap/AstDependency.php
+++ b/src/AstRunner/AstMap/AstDependency.php
@@ -15,6 +15,7 @@ class AstDependency
     public const NEW = 'new';
     public const STATIC_PROPERTY = 'static_property';
     public const STATIC_METHOD = 'static_method';
+    public const METHOD_CALL = 'method_call';
     public const INSTANCEOF = 'instanceof';
     public const CATCH = 'catch';
     public const VARIABLE = 'variable';

--- a/src/AstRunner/AstMap/ReferenceBuilder.php
+++ b/src/AstRunner/AstMap/ReferenceBuilder.php
@@ -175,6 +175,17 @@ abstract class ReferenceBuilder
         return $this;
     }
 
+    public function methodCall(string $classLikeName, int $occursAtLine): self
+    {
+        $this->dependencies[] = AstDependency::fromType(
+            ClassLikeName::fromFQCN($classLikeName),
+            FileOccurrence::fromFilepath($this->filepath, $occursAtLine),
+            AstDependency::METHOD_CALL
+        );
+
+        return $this;
+    }
+
     public function catchStmt(string $classLikeName, int $occursAtLine): self
     {
         $this->dependencies[] = AstDependency::fromType(

--- a/src/AstRunner/Resolver/ClassMethodResolver.php
+++ b/src/AstRunner/Resolver/ClassMethodResolver.php
@@ -1,0 +1,88 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Qossmic\Deptrac\AstRunner\Resolver;
+
+use PhpParser\Node;
+use Qossmic\Deptrac\AstRunner\AstMap\ReferenceBuilder;
+use Roave\BetterReflection\BetterReflection;
+
+class ClassMethodResolver implements DependencyResolver
+{
+    private TypeResolver $typeResolver;
+    private BetterReflection $reflector;
+
+    public function __construct(TypeResolver $typeResolver, BetterReflection $reflector)
+    {
+        $this->typeResolver = $typeResolver;
+        $this->reflector = $reflector;
+    }
+
+    public function processNode(Node $node, ReferenceBuilder $referenceBuilder, TypeScope $typeScope): void
+    {
+        if (!$node instanceof Node\Stmt\ClassMethod) {
+            return;
+        }
+
+        $variablesCache = [];
+
+        foreach ($node->stmts ?? [] as $stmt) {
+            if (!$stmt instanceof Node\Stmt\Expression) {
+                continue;
+            }
+
+            $retType = null;
+
+            if ($stmt->expr instanceof Node\Expr\Assign && $stmt->expr->var instanceof Node\Expr\Variable) {
+                $assignExpr = $stmt->expr;
+                /** @var Node\Expr\Variable $var */
+                $var = $assignExpr->var;
+                $assignExprExpr = $assignExpr->expr;
+
+                if ($assignExprExpr instanceof Node\Expr\New_ && $assignExprExpr->class instanceof Node\Name) {
+                    if ($type = $this->typeResolver->resolvePHPParserTypes($typeScope, $assignExprExpr->class)[0] ?? null) { // TODO handle union types
+                        $variablesCache[$var->name] = $type;
+                    }
+                }
+
+                if ($assignExprExpr instanceof Node\Expr\MethodCall) {
+                    $retType = $this->getReturnTypeFromMethodCall($assignExprExpr, $variablesCache, $referenceBuilder);
+                    $variablesCache[$var->name] = $retType;
+                }
+            }
+
+            if ($stmt->expr instanceof Node\Expr\MethodCall) {
+                $retType = $this->getReturnTypeFromMethodCall($stmt->expr, $variablesCache, $referenceBuilder);
+            }
+
+            if ($stmt->expr->var instanceof Node\Expr\Variable && $retType !== null) {
+                $referenceBuilder->methodCall($retType, $stmt->expr->getStartLine());
+            }
+        }
+    }
+
+    private function getReturnTypeFromMethodCall(Node\Expr\MethodCall $expr, array &$variablesCache, ReferenceBuilder $referenceBuilder)
+    {
+        if ($expr->var instanceof Node\Expr\Variable) {
+            $varType = $variablesCache[$expr->var->name] ?? null;
+        } else if ($expr->var instanceof Node\Expr\MethodCall) {
+            $varType = $this->getReturnTypeFromMethodCall($expr->var, $variablesCache, $referenceBuilder);
+            if ($varType !== null) {
+                $referenceBuilder->methodCall($varType, $expr->getStartLine());
+            }
+        }
+
+        if ($varType !== null) {
+            $classInfo = $this->reflector->classReflector()->reflect($varType);
+            if ($classInfo->hasMethod($expr->name->name)) {
+                $type = $classInfo->getMethod($expr->name->name)->getReturnType();
+                if ($type !== null) {
+                    return $type->getName();
+                }
+            }
+        }
+
+        return null;
+    }
+}

--- a/tests/AstRunner/Fixtures/MethodCall/ContainsViolationWithVariable.php
+++ b/tests/AstRunner/Fixtures/MethodCall/ContainsViolationWithVariable.php
@@ -1,0 +1,16 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Qossmic\Deptrac\AstRunner\Fixtures\MethodCall;
+
+
+class ContainsViolationWithVariable
+{
+    public function doSomething()
+    {
+        $classA = new DummyClassA();
+        $violationClass = $classA->returnViolationClass();
+        $violationClass->foo();
+    }
+}

--- a/tests/AstRunner/Fixtures/MethodCall/ContainsViolationWithoutVariable.php
+++ b/tests/AstRunner/Fixtures/MethodCall/ContainsViolationWithoutVariable.php
@@ -1,0 +1,15 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Qossmic\Deptrac\AstRunner\Fixtures\MethodCall;
+
+
+class ContainsViolationWithoutVariable
+{
+    public function doSomething()
+    {
+        $classA = new DummyClassA();
+        $classA->returnViolationClass()->foo();
+    }
+}

--- a/tests/AstRunner/Fixtures/MethodCall/DummyClassA.php
+++ b/tests/AstRunner/Fixtures/MethodCall/DummyClassA.php
@@ -1,0 +1,13 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Qossmic\Deptrac\AstRunner\Fixtures\MethodCall;
+
+class DummyClassA
+{
+    public function returnViolationClass(): DummyViolationClass
+    {
+        return new DummyViolationClass();
+    }
+}

--- a/tests/AstRunner/Fixtures/MethodCall/DummyViolationClass.php
+++ b/tests/AstRunner/Fixtures/MethodCall/DummyViolationClass.php
@@ -1,0 +1,12 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Qossmic\Deptrac\AstRunner\Fixtures\MethodCall;
+
+class DummyViolationClass
+{
+    public function foo() {
+
+    }
+}

--- a/tests/AstRunner/Resolver/ClassMethodResolverTest.php
+++ b/tests/AstRunner/Resolver/ClassMethodResolverTest.php
@@ -1,0 +1,61 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Qossmic\Deptrac\AstRunner\Resolver;
+
+use PHPUnit\Framework\TestCase;
+use Qossmic\Deptrac\AstRunner\AstParser\AstFileReferenceInMemoryCache;
+use Qossmic\Deptrac\AstRunner\AstParser\NikicPhpParser\NikicPhpParser;
+use Qossmic\Deptrac\AstRunner\AstParser\NikicPhpParser\ParserFactory;
+use Qossmic\Deptrac\AstRunner\Resolver\ClassConstantResolver;
+use Qossmic\Deptrac\AstRunner\Resolver\ClassMethodResolver;
+use Qossmic\Deptrac\AstRunner\Resolver\TypeResolver;
+use Qossmic\Deptrac\Configuration\ConfigurationAnalyser;
+use Roave\BetterReflection\BetterReflection;
+
+final class ClassMethodResolverTest extends TestCase
+{
+    public function violationClassesDataProvider(): array
+    {
+        return [
+            'Contains violation in a variable' => [
+                __DIR__ . '/../Fixtures/MethodCall/ContainsViolationWithVariable.php'
+            ],
+            'Contains violation without a variable' => [
+                __DIR__ . '/../Fixtures/MethodCall/ContainsViolationWithoutVariable.php'
+            ],
+        ];
+    }
+    /**
+     * @dataProvider violationClassesDataProvider
+     */
+    public function testPropertyDependencyResolving(string $filePath): void
+    {
+        $parser = new NikicPhpParser(
+            ParserFactory::createParser(),
+            new AstFileReferenceInMemoryCache(),
+            new TypeResolver(),
+            new ClassConstantResolver(),
+            new ClassMethodResolver(new TypeResolver(), new BetterReflection())
+        );
+        
+        $astFileReference = $parser->parseFile($filePath, ConfigurationAnalyser::fromArray([]));
+
+        $astClassReferences = $astFileReference->getAstClassReferences();
+
+        self::assertCount(1, $astClassReferences);
+
+
+        $dependencies = $astClassReferences[0]->getDependencies();
+        self::assertCount(2, $dependencies);
+        self::assertSame(
+            'Tests\Qossmic\Deptrac\AstRunner\Fixtures\MethodCall\DummyClassA',
+            $dependencies[0]->getTokenName()->toString()
+        );
+        self::assertSame(
+            'Tests\Qossmic\Deptrac\AstRunner\Fixtures\MethodCall\DummyViolationClass',
+            $dependencies[1]->getTokenName()->toString()
+        );
+    }
+}


### PR DESCRIPTION
a new try to resolve #449 
See also #454 as base POC pull request

The following cases are not resolved:
- [ ] test with multiple return types
- [ ] return types with `@var` annotations are not supported
- [ ] test for array return types

And some other tasks where i'm glad to get some help:
- [ ] how to resolve the return types by annotations
- [ ] i use a own variablesCache which doesn't look very good. But i don't know how the variables in the scope are stored.