### PR TITLE
Replace version constant with check against composer runtime.

### DIFF
--- a/box.json.dist
+++ b/box.json.dist
@@ -5,7 +5,6 @@
   ],
   "compression": "GZ",
   "main": "deptrac.php",
-  "git-version": "git-version",
   "compactors" : [
       "KevinGH\\Box\\Compactor\\PhpScoper"
   ],

--- a/composer.json
+++ b/composer.json
@@ -19,6 +19,7 @@
     "require": {
         "php": "^7.4.0 || 8.0.* || 8.1.*",
         "ext-json": "*",
+        "composer-runtime-api": "^2.0",
         "composer/xdebug-handler": "^2.0",
         "jetbrains/phpstorm-stubs": "^2020.2",
         "nikic/php-parser": "^4.3",

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "8457cc3651c7dda1cf502b69a9aecd56",
+    "content-hash": "243f0520a9d548c4c26d3f8d418d0a74",
     "packages": [
         {
             "name": "composer/xdebug-handler",
@@ -2027,7 +2027,8 @@
     "prefer-lowest": false,
     "platform": {
         "php": "^7.4.0 || 8.0.* || 8.1.*",
-        "ext-json": "*"
+        "ext-json": "*",
+        "composer-runtime-api": "^2.0"
     },
     "platform-dev": [],
     "platform-overrides": {

--- a/src/AstRunner/AstParser/AstFileReferenceFileCache.php
+++ b/src/AstRunner/AstParser/AstFileReferenceFileCache.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace Qossmic\Deptrac\AstRunner\AstParser;
 
+use Composer\InstalledVersions;
 use Qossmic\Deptrac\AstRunner\AstMap\AstClassReference;
 use Qossmic\Deptrac\AstRunner\AstMap\AstDependency;
 use Qossmic\Deptrac\AstRunner\AstMap\AstFileReference;
@@ -15,7 +16,6 @@ use Qossmic\Deptrac\AstRunner\AstMap\FileName;
 use Qossmic\Deptrac\AstRunner\AstMap\FileOccurrence;
 use Qossmic\Deptrac\AstRunner\AstMap\FunctionName;
 use Qossmic\Deptrac\AstRunner\AstMap\SuperGlobalName;
-use Qossmic\Deptrac\Console\Application;
 use Qossmic\Deptrac\File\FileReader;
 
 class AstFileReferenceFileCache implements AstFileReferenceCache
@@ -100,7 +100,7 @@ class AstFileReferenceFileCache implements AstFileReferenceCache
 
         $this->loaded = true;
 
-        if (Application::VERSION !== $cache['version']) {
+        if (InstalledVersions::getRootPackage()['version'] !== $cache['version']) {
             return;
         }
 
@@ -163,7 +163,7 @@ class AstFileReferenceFileCache implements AstFileReferenceCache
             $this->cacheFile,
             json_encode(
                 [
-                    'version' => Application::VERSION,
+                    'version' => InstalledVersions::getRootPackage()['version'],
                     'payload' => $payload,
                 ]
             )

--- a/src/Console/Application.php
+++ b/src/Console/Application.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace Qossmic\Deptrac\Console;
 
+use Composer\InstalledVersions;
 use Psr\Container\ContainerInterface;
 use Qossmic\Deptrac\Console\Command\AnalyseCommand;
 use Qossmic\Deptrac\Console\Command\DebugLayerCommand;
@@ -19,11 +20,9 @@ use Symfony\Component\Console\Output\OutputInterface;
 
 final class Application extends BaseApplication
 {
-    public const VERSION = '@git-version@';
-
     public function __construct()
     {
-        parent::__construct('deptrac', self::VERSION);
+        parent::__construct('deptrac', InstalledVersions::getRootPackage()['version']);
 
         $this->getDefinition()->addOptions([
             new InputOption('--no-cache', null, InputOption::VALUE_NONE, 'Disable caching mechanisms'),


### PR DESCRIPTION
Use Composer Runtime utilities to check for root pacakge version.

Currently blocked by Box not fully supporting the Composer Runtime Utilities, yet.

Fixes #704 