### PR TITLE
Fix issue #707

### DIFF
--- a/src/Configuration/ConfigurationAnalyser.php
+++ b/src/Configuration/ConfigurationAnalyser.php
@@ -37,7 +37,7 @@ final class ConfigurationAnalyser
     {
         /** @var array{count_use_statements: bool, types: string[]} $options */
         $options = (new OptionsResolver())
-            ->setDefault('count_use_statements', true)
+            ->setDefault('count_use_statements', !array_key_exists('types', $args))
             ->setDefault('types', [self::CLASS_TOKEN])
             ->addAllowedTypes('count_use_statements', 'bool')
             ->addAllowedTypes('types', 'array')

--- a/src/Configuration/ConfigurationAnalyser.php
+++ b/src/Configuration/ConfigurationAnalyser.php
@@ -51,7 +51,7 @@ final class ConfigurationAnalyser
      */
     private function __construct(array $config)
     {
-        if ($config['count_use_statements']) {
+        if ($config['count_use_statements'] && !in_array(self::USE_TOKEN, $config['types'], true)) {
             $config['types'][] = self::USE_TOKEN;
         }
         unset($config['count_use_statements']);

--- a/tests/Configuration/ConfigurationAnalyserTest.php
+++ b/tests/Configuration/ConfigurationAnalyserTest.php
@@ -36,14 +36,24 @@ final class ConfigurationAnalyserTest extends TestCase
         self::assertSame([ConfigurationAnalyser::CLASS_TOKEN, ConfigurationAnalyser::USE_TOKEN], $configuration->getTypes());
     }
 
-    public function testCustomTypes(): void
+    public function testCustomTypesWithAddedUse(): void
+    {
+        $types = [
+            ConfigurationAnalyser::CLASS_TOKEN,
+            ConfigurationAnalyser::FUNCTION_TOKEN,
+        ];
+        $configuration = ConfigurationAnalyser::fromArray(['count_use_statements' => true, 'types' => $types]);
+        $types[] = ConfigurationAnalyser::USE_TOKEN;
+        self::assertSame($types, $configuration->getTypes());
+    }
+
+    public function testCustomTypesWithDefaultUse(): void
     {
         $types = [
             ConfigurationAnalyser::CLASS_TOKEN,
             ConfigurationAnalyser::FUNCTION_TOKEN,
         ];
         $configuration = ConfigurationAnalyser::fromArray(['types' => $types]);
-        $types[] = ConfigurationAnalyser::USE_TOKEN;
         self::assertSame($types, $configuration->getTypes());
     }
 


### PR DESCRIPTION
Resolves #707

Based on the tests it was the expected behavior, but it is not intuitive. So I changed it to an intuitive version and wrote another test for manually adding the `use` analyzer via deprecated config.