### PR TITLE
Depfile use output instead of symfony

### DIFF
--- a/depfile.baseline.yml
+++ b/depfile.baseline.yml
@@ -1,29 +1,31 @@
 skip_violations:
-  Qossmic\Deptrac\LayerAnalyser:
+  Qossmic\Deptrac\Analyser:
     - Qossmic\Deptrac\AstRunner\AstRunner
   Qossmic\Deptrac\AstRunner\AstParser\AstFileReferenceFileCache:
     - Qossmic\Deptrac\Console\Application
-  Qossmic\Deptrac\TokenLayerResolverFactory:
-    - Qossmic\Deptrac\AstRunner\AstMap
-  Qossmic\Deptrac\TokenAnalyser:
-    - Qossmic\Deptrac\AstRunner\AstRunner
-  Qossmic\Deptrac\Dependency\InheritanceFlatter:
-    - Qossmic\Deptrac\AstRunner\AstMap
-  Qossmic\Deptrac\Dependency\InheritDependency:
-    - Qossmic\Deptrac\AstRunner\AstMap\AstInherit
+  Qossmic\Deptrac\Configuration\Configuration:
+    - Qossmic\Deptrac\Configuration\ConfigurationAnalyser
   Qossmic\Deptrac\Console\Command\DebugTokenOptions:
     - Qossmic\Deptrac\AstRunner\AstMap\ClassLikeName
     - Qossmic\Deptrac\AstRunner\AstMap\FileName
     - Qossmic\Deptrac\AstRunner\AstMap\FunctionName
-  Qossmic\Deptrac\Configuration\Configuration:
-    - Qossmic\Deptrac\Configuration\ConfigurationAnalyser
+  Qossmic\Deptrac\Dependency\InheritanceFlatter:
+    - Qossmic\Deptrac\AstRunner\AstMap
+  Qossmic\Deptrac\Dependency\InheritDependency:
+    - Qossmic\Deptrac\AstRunner\AstMap\AstInherit
+  Qossmic\Deptrac\LayerAnalyser:
+    - Qossmic\Deptrac\AstRunner\AstRunner
+  Qossmic\Deptrac\OutputFormatter\TableOutputFormatter:
+    - Symfony\Component\Console\Helper\TableSeparator
+  Qossmic\Deptrac\TokenAnalyser:
+    - Qossmic\Deptrac\AstRunner\AstRunner
   Qossmic\Deptrac\TokenLayerResolver:
     - Qossmic\Deptrac\AstRunner\AstMap
     - Qossmic\Deptrac\AstRunner\AstMap\AstClassReference
-    - Qossmic\Deptrac\AstRunner\AstMap\AstFunctionReference
     - Qossmic\Deptrac\AstRunner\AstMap\AstFileReference
+    - Qossmic\Deptrac\AstRunner\AstMap\AstFunctionReference
     - Qossmic\Deptrac\AstRunner\AstMap\AstVariableReference
+  Qossmic\Deptrac\TokenLayerResolverFactory:
+    - Qossmic\Deptrac\AstRunner\AstMap
   Qossmic\Deptrac\UnassignedAnalyser:
-    - Qossmic\Deptrac\AstRunner\AstRunner
-  Qossmic\Deptrac\Analyser:
     - Qossmic\Deptrac\AstRunner\AstRunner

--- a/depfile.yaml
+++ b/depfile.yaml
@@ -19,6 +19,12 @@ layers:
         must_not:
           - type: className
             regex: ^Qossmic\\Deptrac\\.*
+          - type: className
+            regex: Symfony\\Component\\Console\\.*
+  - name: SymfonyConsole
+    collectors:
+      - type: className
+        regex: Symfony\\Component\\Console\\.*
   - name: Console Formatters
     collectors:
       - type: implements
@@ -112,6 +118,7 @@ layers:
             regex: .*CacheableFileSubscriber
 
 ruleset:
+  SymfonyConsole: ~
   Console Formatters:
     - Console
     - Application
@@ -121,6 +128,7 @@ ruleset:
     - Application
     - Events
     - Utils
+    - SymfonyConsole
   Application:
     - Dependencies
     - Utils


### PR DESCRIPTION
Refactors ConsoleSubscriber to ensure it uses our own Output object instead of relying on Symfony\Console\Output