### PR TITLE
Update php-cs-fixer rules

### DIFF
--- a/.php-cs-fixer.dist.php
+++ b/.php-cs-fixer.dist.php
@@ -10,13 +10,24 @@ return (new PhpCsFixer\Config())
     ->setRules([
         '@Symfony' => true,
         'array_syntax' => ['syntax' => 'short'],
-        'self_static_accessor' => true,
+        'array_indentation' => true,
+        'global_namespace_import' => [
+            'import_constants' => true,
+            'import_functions' => true,
+            'import_classes' => true,
+        ],
         'no_empty_comment' => true,
         'no_empty_phpdoc' => true,
         'no_superfluous_phpdoc_tags' => ['allow_mixed' => true],
         'no_unused_imports' => true,
+        'octal_notation' => true,
+        'ordered_imports' => [
+            'sort_algorithm' => 'alpha',
+            'imports_order' => ['class', 'function', 'const'],
+        ],
+        'phpdoc_to_comment' => false,
+        'self_static_accessor' => true,
         'static_lambda' => true,
         'strict_param' => true,
-        'phpdoc_to_comment' => false,
     ])
     ->setFinder($finder);

--- a/config/services.php
+++ b/config/services.php
@@ -67,11 +67,11 @@ use Qossmic\Deptrac\TokenAnalyser;
 use Qossmic\Deptrac\TokenLayerResolverFactory;
 use Qossmic\Deptrac\UnassignedAnalyser;
 use Symfony\Component\DependencyInjection\Loader\Configurator\ContainerConfigurator;
+use Symfony\Component\EventDispatcher\EventDispatcher;
+use Symfony\Component\EventDispatcher\EventDispatcherInterface;
 use function Symfony\Component\DependencyInjection\Loader\Configurator\param;
 use function Symfony\Component\DependencyInjection\Loader\Configurator\service;
 use function Symfony\Component\DependencyInjection\Loader\Configurator\tagged_iterator;
-use Symfony\Component\EventDispatcher\EventDispatcher;
-use Symfony\Component\EventDispatcher\EventDispatcherInterface;
 
 return static function (ContainerConfigurator $container): void {
     $services = $container->services();

--- a/src/AstRunner/AstParser/Cache/AstFileReferenceFileCache.php
+++ b/src/AstRunner/AstParser/Cache/AstFileReferenceFileCache.php
@@ -4,14 +4,6 @@ declare(strict_types=1);
 
 namespace Qossmic\Deptrac\AstRunner\AstParser\Cache;
 
-use function array_filter;
-use function array_map;
-use function assert;
-use function file_exists;
-use function is_readable;
-use function is_writable;
-use function json_decode;
-use function json_encode;
 use Qossmic\Deptrac\AstRunner\AstMap\AstClassReference;
 use Qossmic\Deptrac\AstRunner\AstMap\AstDependency;
 use Qossmic\Deptrac\AstRunner\AstMap\AstFileReference;
@@ -26,6 +18,15 @@ use Qossmic\Deptrac\AstRunner\AstMap\SuperGlobalName;
 use Qossmic\Deptrac\Console\Application;
 use Qossmic\Deptrac\Exception\AstRunner\AstParser\FileNotExistsException;
 use Qossmic\Deptrac\File\FileReader;
+use function array_filter;
+use function array_map;
+use function assert;
+use function dirname;
+use function file_exists;
+use function is_readable;
+use function is_writable;
+use function json_decode;
+use function json_encode;
 use function realpath;
 use function sha1_file;
 use function unserialize;
@@ -129,7 +130,7 @@ class AstFileReferenceFileCache implements AstFileReferenceDeferredCacheInterfac
 
     public function write(): void
     {
-        if (!is_writable(\dirname($this->cacheFile))) {
+        if (!is_writable(dirname($this->cacheFile))) {
             return;
         }
 

--- a/src/Collector/FunctionNameCollector.php
+++ b/src/Collector/FunctionNameCollector.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace Qossmic\Deptrac\Collector;
 
+use LogicException;
 use Qossmic\Deptrac\AstRunner\AstMap;
 
 class FunctionNameCollector implements CollectorInterface
@@ -41,7 +42,7 @@ class FunctionNameCollector implements CollectorInterface
     private function getPattern(array $configuration): string
     {
         if (!isset($configuration['regex']) || !is_string($configuration['regex'])) {
-            throw new \LogicException('FunctionNameCollector needs the regex configuration.');
+            throw new LogicException('FunctionNameCollector needs the regex configuration.');
         }
 
         return '/'.$configuration['regex'].'/i';

--- a/src/Collector/LayerCollector.php
+++ b/src/Collector/LayerCollector.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace Qossmic\Deptrac\Collector;
 
+use InvalidArgumentException;
 use Qossmic\Deptrac\AstRunner\AstMap;
 
 class LayerCollector implements CollectorInterface
@@ -21,10 +22,10 @@ class LayerCollector implements CollectorInterface
         array $allLayersConfiguration = []
     ): bool {
         if (!isset($configuration['layer']) || !is_string($configuration['layer'])) {
-            throw new \InvalidArgumentException('LayerCollector needs the layer configuration.');
+            throw new InvalidArgumentException('LayerCollector needs the layer configuration.');
         }
         if (!array_key_exists($configuration['layer'], $allLayersConfiguration)) {
-            throw new \InvalidArgumentException('Referenced layer in LayerCollector does not exist.');
+            throw new InvalidArgumentException('Referenced layer in LayerCollector does not exist.');
         }
 
         $layerConfig = $allLayersConfiguration[$configuration['layer']];

--- a/src/Collector/RegexCollector.php
+++ b/src/Collector/RegexCollector.php
@@ -4,6 +4,8 @@ declare(strict_types=1);
 
 namespace Qossmic\Deptrac\Collector;
 
+use LogicException;
+
 abstract class RegexCollector
 {
     /**
@@ -25,6 +27,6 @@ abstract class RegexCollector
         if (false !== @preg_match($pattern, '')) {
             return $pattern;
         }
-        throw new \LogicException('Invalid regex pattern '.$pattern);
+        throw new LogicException('Invalid regex pattern '.$pattern);
     }
 }

--- a/src/Configuration/ConfigurationAnalyser.php
+++ b/src/Configuration/ConfigurationAnalyser.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace Qossmic\Deptrac\Configuration;
 
+use InvalidArgumentException;
 use Qossmic\Deptrac\Exception\Configuration\InvalidConfigurationException;
 use Symfony\Component\OptionsResolver\OptionsResolver;
 
@@ -58,7 +59,7 @@ final class ConfigurationAnalyser
 
         foreach ($config['types'] as $type) {
             if (!in_array($type, self::RECOGNIZED_TOKENS, true)) {
-                throw new \InvalidArgumentException('Unsupported analyser type: '.$type);
+                throw new InvalidArgumentException('Unsupported analyser type: '.$type);
             }
         }
         $this->config = $config;

--- a/src/Configuration/Loader.php
+++ b/src/Configuration/Loader.php
@@ -4,17 +4,17 @@ declare(strict_types=1);
 
 namespace Qossmic\Deptrac\Configuration;
 
-use function array_filter;
-use function array_key_exists;
-use function array_merge;
-use function dirname;
 use Qossmic\Deptrac\Configuration\Loader\YmlFileLoader;
 use Qossmic\Deptrac\Exception\Configuration\FileCannotBeParsedAsYamlException;
 use Qossmic\Deptrac\Exception\Configuration\ParsedYamlIsNotAnArrayException;
 use Qossmic\Deptrac\Exception\File\CouldNotReadFileException;
-use function sprintf;
 use Symfony\Component\Config\Definition\Processor;
 use Symfony\Component\Filesystem\Path;
+use function array_filter;
+use function array_key_exists;
+use function array_merge;
+use function dirname;
+use function sprintf;
 use function trigger_deprecation;
 
 class Loader

--- a/src/Console/Application.php
+++ b/src/Console/Application.php
@@ -4,8 +4,6 @@ declare(strict_types=1);
 
 namespace Qossmic\Deptrac\Console;
 
-use const DIRECTORY_SEPARATOR;
-use function getcwd;
 use Qossmic\Deptrac\Exception\ShouldNotHappenException;
 use RuntimeException;
 use Symfony\Component\Console\Application as BaseApplication;
@@ -15,6 +13,8 @@ use Symfony\Component\Console\Input\InputDefinition;
 use Symfony\Component\Console\Input\InputInterface;
 use Symfony\Component\Console\Input\InputOption;
 use Symfony\Component\Console\Output\OutputInterface;
+use function getcwd;
+use const DIRECTORY_SEPARATOR;
 
 final class Application extends BaseApplication
 {

--- a/src/Console/Command/AnalyseCommand.php
+++ b/src/Console/Command/AnalyseCommand.php
@@ -4,8 +4,6 @@ declare(strict_types=1);
 
 namespace Qossmic\Deptrac\Console\Command;
 
-use const DIRECTORY_SEPARATOR;
-use function getcwd;
 use Qossmic\Deptrac\Console\Symfony\Style;
 use Qossmic\Deptrac\Console\Symfony\SymfonyOutput;
 use Qossmic\Deptrac\Env;
@@ -22,6 +20,8 @@ use Symfony\Component\Console\Input\InputOption;
 use Symfony\Component\Console\Output\OutputInterface;
 use Symfony\Component\Console\Style\SymfonyStyle;
 use Symfony\Component\EventDispatcher\EventDispatcherInterface;
+use function getcwd;
+use const DIRECTORY_SEPARATOR;
 
 class AnalyseCommand extends Command
 {

--- a/src/Console/Command/AnalyseOptions.php
+++ b/src/Console/Command/AnalyseOptions.php
@@ -2,8 +2,8 @@
 
 namespace Qossmic\Deptrac\Console\Command;
 
-use function is_string;
 use Qossmic\Deptrac\Exception\Console\InvalidArgumentException;
+use function is_string;
 
 class AnalyseOptions
 {

--- a/src/Console/Command/AnalyseRunner.php
+++ b/src/Console/Command/AnalyseRunner.php
@@ -4,7 +4,6 @@ declare(strict_types=1);
 
 namespace Qossmic\Deptrac\Console\Command;
 
-use function implode;
 use LogicException;
 use Qossmic\Deptrac\Analyser;
 use Qossmic\Deptrac\Configuration\Loader as ConfigurationLoader;
@@ -12,8 +11,9 @@ use Qossmic\Deptrac\Console\Output;
 use Qossmic\Deptrac\Exception\Console\AnalyseException;
 use Qossmic\Deptrac\OutputFormatter\OutputFormatterInput;
 use Qossmic\Deptrac\OutputFormatterFactory;
-use function sprintf;
 use Throwable;
+use function implode;
+use function sprintf;
 
 /**
  * @internal Should only be used by AnalyseCommand

--- a/src/Console/Command/DebugLayerOptions.php
+++ b/src/Console/Command/DebugLayerOptions.php
@@ -2,8 +2,8 @@
 
 namespace Qossmic\Deptrac\Console\Command;
 
-use function is_string;
 use Qossmic\Deptrac\Exception\Console\InvalidArgumentException;
+use function is_string;
 
 class DebugLayerOptions
 {

--- a/src/Console/Command/DebugLayerRunner.php
+++ b/src/Console/Command/DebugLayerRunner.php
@@ -4,13 +4,13 @@ declare(strict_types=1);
 
 namespace Qossmic\Deptrac\Console\Command;
 
-use function array_map;
-use function in_array;
 use Qossmic\Deptrac\Configuration\ConfigurationLayer;
 use Qossmic\Deptrac\Configuration\Loader;
 use Qossmic\Deptrac\Console\Output;
 use Qossmic\Deptrac\Exception\Console\InvalidLayerException;
 use Qossmic\Deptrac\LayerAnalyser;
+use function array_map;
+use function in_array;
 
 /**
  * @internal Should only be used by DebugLayerCommand

--- a/src/Console/Command/DebugTokenOptions.php
+++ b/src/Console/Command/DebugTokenOptions.php
@@ -2,12 +2,12 @@
 
 namespace Qossmic\Deptrac\Console\Command;
 
-use function is_string;
 use Qossmic\Deptrac\AstRunner\AstMap\ClassLikeName;
 use Qossmic\Deptrac\AstRunner\AstMap\FileName;
 use Qossmic\Deptrac\AstRunner\AstMap\FunctionName;
 use Qossmic\Deptrac\Exception\Console\InvalidArgumentException;
 use Qossmic\Deptrac\Exception\Console\InvalidTokenException;
+use function is_string;
 
 class DebugTokenOptions
 {

--- a/src/Console/Command/DebugTokenRunner.php
+++ b/src/Console/Command/DebugTokenRunner.php
@@ -4,10 +4,10 @@ declare(strict_types=1);
 
 namespace Qossmic\Deptrac\Console\Command;
 
-use function natcasesort;
 use Qossmic\Deptrac\Configuration\Loader;
 use Qossmic\Deptrac\Console\Output;
 use Qossmic\Deptrac\TokenAnalyser;
+use function natcasesort;
 
 /**
  * @internal Should only be used by DebugTokenCommand

--- a/src/Console/Command/DebugUnassignedOptions.php
+++ b/src/Console/Command/DebugUnassignedOptions.php
@@ -2,8 +2,8 @@
 
 namespace Qossmic\Deptrac\Console\Command;
 
-use function is_string;
 use Qossmic\Deptrac\Exception\Console\InvalidArgumentException;
+use function is_string;
 
 class DebugUnassignedOptions
 {

--- a/src/Console/Command/DefaultDepFileTrait.php
+++ b/src/Console/Command/DefaultDepFileTrait.php
@@ -4,9 +4,9 @@ declare(strict_types=1);
 
 namespace Qossmic\Deptrac\Console\Command;
 
-use function file_exists;
 use Qossmic\Deptrac\Console\Output;
 use Symfony\Component\Console\Input\InputInterface;
+use function file_exists;
 use function trigger_deprecation;
 
 trait DefaultDepFileTrait

--- a/src/Exception/Console/InvalidTokenException.php
+++ b/src/Exception/Console/InvalidTokenException.php
@@ -4,9 +4,9 @@ declare(strict_types=1);
 
 namespace Qossmic\Deptrac\Exception\Console;
 
-use function implode;
 use Qossmic\Deptrac\Exception\ExceptionInterface;
 use RuntimeException;
+use function implode;
 
 final class InvalidTokenException extends RuntimeException implements ExceptionInterface
 {

--- a/src/LayerAnalyser.php
+++ b/src/LayerAnalyser.php
@@ -4,9 +4,9 @@ declare(strict_types=1);
 
 namespace Qossmic\Deptrac;
 
-use function in_array;
 use Qossmic\Deptrac\AstRunner\AstRunner;
 use Qossmic\Deptrac\Configuration\Configuration;
+use function in_array;
 use const true;
 
 class LayerAnalyser

--- a/src/OutputFormatter/BaselineOutputFormatter.php
+++ b/src/OutputFormatter/BaselineOutputFormatter.php
@@ -4,14 +4,14 @@ declare(strict_types=1);
 
 namespace Qossmic\Deptrac\OutputFormatter;
 
-use function array_values;
-use function ksort;
 use Qossmic\Deptrac\Console\Output;
 use Qossmic\Deptrac\RulesetEngine\Context;
 use Qossmic\Deptrac\RulesetEngine\SkippedViolation;
 use Qossmic\Deptrac\RulesetEngine\Violation;
-use function sort;
 use Symfony\Component\Yaml\Yaml;
+use function array_values;
+use function ksort;
+use function sort;
 
 final class BaselineOutputFormatter implements OutputFormatterInterface
 {

--- a/src/OutputFormatter/ConsoleOutputFormatter.php
+++ b/src/OutputFormatter/ConsoleOutputFormatter.php
@@ -4,7 +4,6 @@ declare(strict_types=1);
 
 namespace Qossmic\Deptrac\OutputFormatter;
 
-use function count;
 use Qossmic\Deptrac\AstRunner\AstMap\FileOccurrence;
 use Qossmic\Deptrac\Console\Output;
 use Qossmic\Deptrac\Dependency\InheritDependency;
@@ -12,6 +11,7 @@ use Qossmic\Deptrac\RulesetEngine\Context;
 use Qossmic\Deptrac\RulesetEngine\Rule;
 use Qossmic\Deptrac\RulesetEngine\SkippedViolation;
 use Qossmic\Deptrac\RulesetEngine\Violation;
+use function count;
 
 final class ConsoleOutputFormatter implements OutputFormatterInterface
 {

--- a/src/OutputFormatter/GraphVizOutputDisplayFormatter.php
+++ b/src/OutputFormatter/GraphVizOutputDisplayFormatter.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace Qossmic\Deptrac\OutputFormatter;
 
+use LogicException;
 use phpDocumentor\GraphViz\Exception;
 use phpDocumentor\GraphViz\Graph;
 use Qossmic\Deptrac\Console\Output;
@@ -36,7 +37,7 @@ final class GraphVizOutputDisplayFormatter extends GraphVizOutputFormatter
             }
             $next = microtime(true) + (float) self::DELAY_OPEN;
         } catch (Exception $exception) {
-            throw new \LogicException('Unable to display output: '.$exception->getMessage());
+            throw new LogicException('Unable to display output: '.$exception->getMessage());
         }
     }
 }

--- a/src/OutputFormatter/GraphVizOutputFormatter.php
+++ b/src/OutputFormatter/GraphVizOutputFormatter.php
@@ -15,6 +15,7 @@ use Qossmic\Deptrac\RulesetEngine\CoveredRule;
 use Qossmic\Deptrac\RulesetEngine\Rule;
 use Qossmic\Deptrac\RulesetEngine\Uncovered;
 use Qossmic\Deptrac\RulesetEngine\Violation;
+use RuntimeException;
 use function sys_get_temp_dir;
 use function tempnam;
 
@@ -203,7 +204,7 @@ abstract class GraphVizOutputFormatter implements OutputFormatterInterface
     {
         $filename = tempnam(sys_get_temp_dir(), 'deptrac');
         if (false === $filename) {
-            throw new \RuntimeException('Unable to create temp file for output.');
+            throw new RuntimeException('Unable to create temp file for output.');
         }
         $filename .= '.png';
         $graph->export('png', $filename);

--- a/src/OutputFormatter/GraphVizOutputHtmlFormatter.php
+++ b/src/OutputFormatter/GraphVizOutputHtmlFormatter.php
@@ -4,11 +4,13 @@ declare(strict_types=1);
 
 namespace Qossmic\Deptrac\OutputFormatter;
 
-use function base64_encode;
-use function file_get_contents;
+use LogicException;
 use phpDocumentor\GraphViz\Exception;
 use phpDocumentor\GraphViz\Graph;
 use Qossmic\Deptrac\Console\Output;
+use RuntimeException;
+use function base64_encode;
+use function file_get_contents;
 
 final class GraphVizOutputHtmlFormatter extends GraphVizOutputFormatter
 {
@@ -25,7 +27,7 @@ final class GraphVizOutputHtmlFormatter extends GraphVizOutputFormatter
                 $filename = $this->getTempImage($graph);
                 $imageData = file_get_contents($filename);
                 if (false === $imageData) {
-                    throw new \RuntimeException('Unable to create temp file for output.');
+                    throw new RuntimeException('Unable to create temp file for output.');
                 }
                 file_put_contents(
                     $dumpHtmlPath,
@@ -33,7 +35,7 @@ final class GraphVizOutputHtmlFormatter extends GraphVizOutputFormatter
                 );
                 $output->writeLineFormatted('<info>HTML dumped to '.realpath($dumpHtmlPath).'</info>');
             } catch (Exception $exception) {
-                throw new \LogicException('Unable to generate HTML file: '.$exception->getMessage());
+                throw new LogicException('Unable to generate HTML file: '.$exception->getMessage());
             } finally {
                 /** @psalm-suppress RedundantCondition */
                 if (isset($filename) && false !== $filename) {

--- a/src/OutputFormatter/GraphVizOutputImageFormatter.php
+++ b/src/OutputFormatter/GraphVizOutputImageFormatter.php
@@ -4,9 +4,11 @@ declare(strict_types=1);
 
 namespace Qossmic\Deptrac\OutputFormatter;
 
+use LogicException;
 use phpDocumentor\GraphViz\Exception;
 use phpDocumentor\GraphViz\Graph;
 use Qossmic\Deptrac\Console\Output;
+use SplFileInfo;
 
 final class GraphVizOutputImageFormatter extends GraphVizOutputFormatter
 {
@@ -19,15 +21,15 @@ final class GraphVizOutputImageFormatter extends GraphVizOutputFormatter
     {
         $dumpImagePath = $outputFormatterInput->getOutputPath();
         if (null !== $dumpImagePath) {
-            $imageFile = new \SplFileInfo($dumpImagePath);
+            $imageFile = new SplFileInfo($dumpImagePath);
             if (!is_dir($imageFile->getPath()) && !mkdir($imageFile->getPath())) {
-                throw new \LogicException(sprintf('Unable to dump image: Path "%s" does not exist and is not writable.', $imageFile->getPath()));
+                throw new LogicException(sprintf('Unable to dump image: Path "%s" does not exist and is not writable.', $imageFile->getPath()));
             }
             try {
                 $graph->export('png', $dumpImagePath);
                 $output->writeLineFormatted('<info>Image dumped to '.realpath($dumpImagePath).'</info>');
             } catch (Exception $exception) {
-                throw new \LogicException('Unable to display output: '.$exception->getMessage());
+                throw new LogicException('Unable to display output: '.$exception->getMessage());
             }
         }
     }

--- a/src/OutputFormatter/JsonOutputFormatter.php
+++ b/src/OutputFormatter/JsonOutputFormatter.php
@@ -5,14 +5,15 @@ declare(strict_types=1);
 namespace Qossmic\Deptrac\OutputFormatter;
 
 use Exception;
-use function json_encode;
-use function json_last_error;
 use Qossmic\Deptrac\Console\Output;
 use Qossmic\Deptrac\RulesetEngine\Context;
 use Qossmic\Deptrac\RulesetEngine\SkippedViolation;
 use Qossmic\Deptrac\RulesetEngine\Uncovered;
 use Qossmic\Deptrac\RulesetEngine\Violation;
+use function json_encode;
+use function json_last_error;
 use function sprintf;
+use const JSON_PRETTY_PRINT;
 
 final class JsonOutputFormatter implements OutputFormatterInterface
 {
@@ -78,7 +79,7 @@ final class JsonOutputFormatter implements OutputFormatterInterface
         }
 
         $jsonArray['files'] = $violations;
-        $json = json_encode($jsonArray, \JSON_PRETTY_PRINT);
+        $json = json_encode($jsonArray, JSON_PRETTY_PRINT);
 
         if (false === $json) {
             throw new Exception(sprintf('Unable to render json output. %s', $this->jsonLastError()));

--- a/src/OutputFormatter/TableOutputFormatter.php
+++ b/src/OutputFormatter/TableOutputFormatter.php
@@ -4,7 +4,6 @@ declare(strict_types=1);
 
 namespace Qossmic\Deptrac\OutputFormatter;
 
-use function count;
 use Qossmic\Deptrac\Console\Output;
 use Qossmic\Deptrac\Dependency\InheritDependency;
 use Qossmic\Deptrac\RulesetEngine\Allowed;
@@ -16,6 +15,7 @@ use Qossmic\Deptrac\RulesetEngine\Uncovered;
 use Qossmic\Deptrac\RulesetEngine\Violation;
 use Qossmic\Deptrac\RulesetEngine\Warning;
 use Symfony\Component\Console\Helper\TableSeparator;
+use function count;
 
 final class TableOutputFormatter implements OutputFormatterInterface
 {

--- a/src/PathNameFilterIterator.php
+++ b/src/PathNameFilterIterator.php
@@ -4,9 +4,9 @@ declare(strict_types=1);
 
 namespace Qossmic\Deptrac;
 
-use const DIRECTORY_SEPARATOR;
 use Symfony\Component\Filesystem\Path;
 use Symfony\Component\Finder\Iterator\PathFilterIterator;
+use const DIRECTORY_SEPARATOR;
 
 class PathNameFilterIterator extends PathFilterIterator
 {

--- a/src/RulesetEngine/SkippedViolationHelper.php
+++ b/src/RulesetEngine/SkippedViolationHelper.php
@@ -4,6 +4,8 @@ declare(strict_types=1);
 
 namespace Qossmic\Deptrac\RulesetEngine;
 
+use function in_array;
+
 /**
  * @psalm-immutable
  */
@@ -30,7 +32,7 @@ final class SkippedViolationHelper
 
     public function isViolationSkipped(string $dependant, string $dependee): bool
     {
-        $matched = isset($this->skippedViolation[$dependant]) && \in_array($dependee, $this->skippedViolation[$dependant], true);
+        $matched = isset($this->skippedViolation[$dependant]) && in_array($dependee, $this->skippedViolation[$dependant], true);
 
         if ($matched && false !== ($key = array_search($dependee, $this->unmatchedSkippedViolation[$dependant], true))) {
             unset($this->unmatchedSkippedViolation[$dependant][$key]);

--- a/src/TokenLayerResolver.php
+++ b/src/TokenLayerResolver.php
@@ -11,6 +11,7 @@ use Qossmic\Deptrac\Configuration\Configuration;
 use Qossmic\Deptrac\Configuration\ConfigurationLayer;
 use Qossmic\Deptrac\Configuration\ParameterResolver;
 use Qossmic\Deptrac\Exception\ShouldNotHappenException;
+use RuntimeException;
 
 class TokenLayerResolver implements TokenLayerResolverInterface
 {
@@ -84,7 +85,7 @@ class TokenLayerResolver implements TokenLayerResolverInterface
                 $layerRegistry[] = $configurationLayer->getName();
             }
             if ($resolvedBeforeLoop === count($layerRegistry)) {
-                throw new \RuntimeException('Circular dependency between layers detected');
+                throw new RuntimeException('Circular dependency between layers detected');
             }
             $resolvedBeforeLoop = count($layerRegistry);
         }

--- a/tests/AstRunner/AstParser/NikicPhpParser/NikicPhpParserTest.php
+++ b/tests/AstRunner/AstParser/NikicPhpParser/NikicPhpParserTest.php
@@ -12,6 +12,8 @@ use Qossmic\Deptrac\AstRunner\AstParser\NikicPhpParser\ParserFactory;
 use Qossmic\Deptrac\AstRunner\Resolver\TypeResolver;
 use Qossmic\Deptrac\Configuration\Configuration;
 use Qossmic\Deptrac\Configuration\ConfigurationAnalyser;
+use stdClass;
+use TypeError;
 
 final class NikicPhpParserTest extends TestCase
 {
@@ -28,8 +30,8 @@ final class NikicPhpParserTest extends TestCase
 
     public function testParseWithInvalidData(): void
     {
-        $this->expectException(\TypeError::class);
-        $this->parser->parseFile(new \stdClass(), ConfigurationAnalyser::fromArray([]));
+        $this->expectException(TypeError::class);
+        $this->parser->parseFile(new stdClass(), ConfigurationAnalyser::fromArray([]));
     }
 
     public function testParseDoesNotIgnoreUsesByDefault(): void

--- a/tests/Collector/BoolCollectorTest.php
+++ b/tests/Collector/BoolCollectorTest.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace Tests\Qossmic\Deptrac\Collector;
 
+use InvalidArgumentException;
 use PHPUnit\Framework\TestCase;
 use Qossmic\Deptrac\AstRunner\AstMap;
 use Qossmic\Deptrac\AstRunner\AstMap\AstClassReference;
@@ -16,7 +17,7 @@ final class BoolCollectorTest extends TestCase
 {
     public function testSatisfy(): void
     {
-        $this->expectException(\InvalidArgumentException::class);
+        $this->expectException(InvalidArgumentException::class);
         $this->expectExceptionMessage('"bool" collector must have a "must" or a "must_not" attribute.');
 
         (new BoolCollector())->satisfy(
@@ -40,7 +41,7 @@ final class BoolCollectorTest extends TestCase
         $collectorRegistry = $this->createMock(Registry::class);
         $collectorRegistry->method('getCollector')
             ->willReturnMap([
-                 [(new ClassNameCollector())->getType(), new ClassNameCollector()],
+                [(new ClassNameCollector())->getType(), new ClassNameCollector()],
             ]);
 
         $stat = (new BoolCollector())->resolvable($configuration, $collectorRegistry, []);

--- a/tests/Collector/ClassNameCollectorTest.php
+++ b/tests/Collector/ClassNameCollectorTest.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace Tests\Qossmic\Deptrac\Collector;
 
+use LogicException;
 use PHPUnit\Framework\TestCase;
 use Qossmic\Deptrac\AstRunner\AstMap;
 use Qossmic\Deptrac\AstRunner\AstMap\AstClassReference;
@@ -40,7 +41,7 @@ final class ClassNameCollectorTest extends TestCase
 
     public function testWrongRegexParam(): void
     {
-        $this->expectException(\LogicException::class);
+        $this->expectException(LogicException::class);
 
         (new ClassNameCollector())->satisfy(
             ['Foo' => 'a'],
@@ -52,7 +53,7 @@ final class ClassNameCollectorTest extends TestCase
 
     public function testInvalidRegexParam(): void
     {
-        $this->expectException(\LogicException::class);
+        $this->expectException(LogicException::class);
 
         (new ClassNameCollector())->satisfy(
             ['regex' => '/'],

--- a/tests/Collector/ClassNameRegexCollectorTest.php
+++ b/tests/Collector/ClassNameRegexCollectorTest.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace Tests\Qossmic\Deptrac\Collector;
 
+use LogicException;
 use PHPUnit\Framework\TestCase;
 use Qossmic\Deptrac\AstRunner\AstMap;
 use Qossmic\Deptrac\AstRunner\AstMap\AstClassReference;
@@ -41,7 +42,7 @@ final class ClassNameRegexCollectorTest extends TestCase
 
     public function testWrongRegexParam(): void
     {
-        $this->expectException(\LogicException::class);
+        $this->expectException(LogicException::class);
 
         (new ClassNameRegexCollector())->satisfy(
             ['Foo' => 'a'],
@@ -53,7 +54,7 @@ final class ClassNameRegexCollectorTest extends TestCase
 
     public function testInvalidRegexParam(): void
     {
-        $this->expectException(\LogicException::class);
+        $this->expectException(LogicException::class);
 
         (new ClassNameRegexCollector())->satisfy(
             ['regex' => '/'],

--- a/tests/Collector/DirectoryCollectorTest.php
+++ b/tests/Collector/DirectoryCollectorTest.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace Tests\Qossmic\Deptrac\Collector;
 
+use LogicException;
 use PHPUnit\Framework\TestCase;
 use Qossmic\Deptrac\AstRunner\AstMap;
 use Qossmic\Deptrac\Collector\DirectoryCollector;
@@ -49,7 +50,7 @@ final class DirectoryCollectorTest extends TestCase
         $fileReferenceBuilder->newClassLike('Test');
         $fileReference = $fileReferenceBuilder->build();
 
-        $this->expectException(\LogicException::class);
+        $this->expectException(LogicException::class);
         $this->expectExceptionMessage('DirectoryCollector needs the regex configuration.');
 
         (new DirectoryCollector())->satisfy(
@@ -66,7 +67,7 @@ final class DirectoryCollectorTest extends TestCase
         $fileReferenceBuilder->newClassLike('Test');
         $fileReference = $fileReferenceBuilder->build();
 
-        $this->expectException(\LogicException::class);
+        $this->expectException(LogicException::class);
 
         (new DirectoryCollector())->satisfy(
             ['regex' => '\\'],

--- a/tests/Collector/FunctionNameCollectorTest.php
+++ b/tests/Collector/FunctionNameCollectorTest.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace Tests\Qossmic\Deptrac\Collector;
 
+use LogicException;
 use PHPUnit\Framework\TestCase;
 use Qossmic\Deptrac\AstRunner\AstMap;
 use Qossmic\Deptrac\Collector\FunctionNameCollector;
@@ -39,7 +40,7 @@ final class FunctionNameCollectorTest extends TestCase
 
     public function testWrongRegexParam(): void
     {
-        $this->expectException(\LogicException::class);
+        $this->expectException(LogicException::class);
 
         (new FunctionNameCollector())->satisfy(
             ['Foo' => 'a'],

--- a/tests/Collector/LayerCollectorTest.php
+++ b/tests/Collector/LayerCollectorTest.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace Tests\Qossmic\Deptrac\Collector;
 
+use InvalidArgumentException;
 use PHPUnit\Framework\TestCase;
 use Qossmic\Deptrac\AstRunner\AstMap;
 use Qossmic\Deptrac\AstRunner\AstMap\AstClassReference;
@@ -16,7 +17,7 @@ final class LayerCollectorTest extends TestCase
 {
     public function testConfig(): void
     {
-        $this->expectException(\InvalidArgumentException::class);
+        $this->expectException(InvalidArgumentException::class);
         $this->expectExceptionMessage('LayerCollector needs the layer configuration');
 
         (new LayerCollector())->satisfy(
@@ -64,8 +65,8 @@ final class LayerCollectorTest extends TestCase
         $collectorRegistry = $this->createMock(Registry::class);
         $collectorRegistry->method('getCollector')
             ->willReturnMap([
-                                [(new ClassNameCollector())->getType(), new ClassNameCollector()],
-                            ]);
+                [(new ClassNameCollector())->getType(), new ClassNameCollector()],
+            ]);
         $resolved = (new LayerCollector())->satisfy(
             $configuration['layerCollectorLayer']->getCollectors()[0]->getArgs(),
             new AstClassReference(AstMap\ClassLikeName::fromFQCN($className)),

--- a/tests/Collector/MethodCollectorTest.php
+++ b/tests/Collector/MethodCollectorTest.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace Tests\Qossmic\Deptrac\Collector;
 
+use LogicException;
 use PhpParser\Node;
 use PHPUnit\Framework\TestCase;
 use Qossmic\Deptrac\AstRunner\AstMap;
@@ -12,6 +13,7 @@ use Qossmic\Deptrac\AstRunner\AstMap\ClassLikeName;
 use Qossmic\Deptrac\AstRunner\AstParser\NikicPhpParser\NikicPhpParser;
 use Qossmic\Deptrac\Collector\MethodCollector;
 use Qossmic\Deptrac\Collector\Registry;
+use stdClass;
 
 final class MethodCollectorTest extends TestCase
 {
@@ -100,7 +102,7 @@ final class MethodCollectorTest extends TestCase
         $astClassReference = new AstClassReference(ClassLikeName::fromFQCN('foo'));
         $parser = $this->createMock(NikicPhpParser::class);
 
-        $this->expectException(\LogicException::class);
+        $this->expectException(LogicException::class);
         $this->expectExceptionMessage('MethodCollector needs the name configuration.');
 
         (new MethodCollector($parser))->satisfy(
@@ -116,7 +118,7 @@ final class MethodCollectorTest extends TestCase
         $astClassReference = new AstClassReference(ClassLikeName::fromFQCN('foo'));
         $parser = $this->createMock(NikicPhpParser::class);
 
-        $this->expectException(\LogicException::class);
+        $this->expectException(LogicException::class);
 
         (new MethodCollector($parser))->satisfy(
             ['name' => '/'],
@@ -126,9 +128,9 @@ final class MethodCollectorTest extends TestCase
         );
     }
 
-    private function getClassMethod(string $name): \stdClass
+    private function getClassMethod(string $name): stdClass
     {
-        $classMethod = new \stdClass();
+        $classMethod = new stdClass();
         $classMethod->name = $name;
 
         return $classMethod;

--- a/tests/Collector/RegistryTest.php
+++ b/tests/Collector/RegistryTest.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace Tests\Qossmic\Deptrac\Collector;
 
+use InvalidArgumentException;
 use PHPUnit\Framework\TestCase;
 use Qossmic\Deptrac\Collector\BoolCollector;
 use Qossmic\Deptrac\Collector\ClassNameCollector;
@@ -27,7 +28,7 @@ final class RegistryTest extends TestCase
 
     public function testGetUnknownCollector(): void
     {
-        $this->expectException(\InvalidArgumentException::class);
+        $this->expectException(InvalidArgumentException::class);
 
         (new Registry([]))->getCollector('foo');
     }

--- a/tests/Collector/SuperglobalCollectorTest.php
+++ b/tests/Collector/SuperglobalCollectorTest.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace Tests\Qossmic\Deptrac\Collector;
 
+use LogicException;
 use PHPUnit\Framework\TestCase;
 use Qossmic\Deptrac\AstRunner\AstMap;
 use Qossmic\Deptrac\Collector\Registry;
@@ -39,7 +40,7 @@ final class SuperglobalCollectorTest extends TestCase
 
     public function testWrongRegexParam(): void
     {
-        $this->expectException(\LogicException::class);
+        $this->expectException(LogicException::class);
 
         (new SuperglobalCollector())->satisfy(
             ['Foo' => 'a'],

--- a/tests/Configuration/ConfigurationAnalyserTest.php
+++ b/tests/Configuration/ConfigurationAnalyserTest.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace Tests\Qossmic\Deptrac\Configuration;
 
+use InvalidArgumentException;
 use PHPUnit\Framework\TestCase;
 use Qossmic\Deptrac\Configuration\ConfigurationAnalyser;
 
@@ -59,7 +60,7 @@ final class ConfigurationAnalyserTest extends TestCase
 
     public function testUnknownTypes(): void
     {
-        $this->expectException(\InvalidArgumentException::class);
+        $this->expectException(InvalidArgumentException::class);
 
         ConfigurationAnalyser::fromArray([
             'types' => [

--- a/tests/Configuration/ConfigurationCollectorTest.php
+++ b/tests/Configuration/ConfigurationCollectorTest.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace Tests\Qossmic\Deptrac\Configuration;
 
+use InvalidArgumentException;
 use PHPUnit\Framework\TestCase;
 use Qossmic\Deptrac\Configuration\ConfigurationCollector;
 
@@ -11,7 +12,7 @@ final class ConfigurationCollectorTest extends TestCase
 {
     public function testInvalidFromArray(): void
     {
-        $this->expectException(\InvalidArgumentException::class);
+        $this->expectException(InvalidArgumentException::class);
 
         ConfigurationCollector::fromArray([]);
     }

--- a/tests/Configuration/ConfigurationRulesetTest.php
+++ b/tests/Configuration/ConfigurationRulesetTest.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace Tests\Qossmic\Deptrac\Configuration;
 
+use InvalidArgumentException;
 use PHPUnit\Framework\TestCase;
 use Qossmic\Deptrac\Configuration\ConfigurationRuleset;
 
@@ -43,7 +44,7 @@ final class ConfigurationRulesetTest extends TestCase
             'b' => ['+c'],
             'c' => ['+a'],
         ], [], false);
-        $this->expectException(\InvalidArgumentException::class);
+        $this->expectException(InvalidArgumentException::class);
         $configurationRuleSet->getAllowedDependencies('a');
     }
 }

--- a/tests/Configuration/ConfigurationTest.php
+++ b/tests/Configuration/ConfigurationTest.php
@@ -21,24 +21,24 @@ final class ConfigurationTest extends TestCase
         Configuration::fromArray([
             'layers' => [
                 [
-                   'name' => 'foo',
-                   'collectors' => [],
+                    'name' => 'foo',
+                    'collectors' => [],
                 ],
                 [
-                   'name' => 'foo',
-                   'collectors' => [],
+                    'name' => 'foo',
+                    'collectors' => [],
                 ],
                 [
-                   'name' => 'bar',
-                   'collectors' => [],
+                    'name' => 'bar',
+                    'collectors' => [],
                 ],
                 [
-                   'name' => 'baz',
-                   'collectors' => [],
+                    'name' => 'baz',
+                    'collectors' => [],
                 ],
                 [
-                   'name' => 'baz',
-                   'collectors' => [],
+                    'name' => 'baz',
+                    'collectors' => [],
                 ],
             ],
             'paths' => [
@@ -64,16 +64,16 @@ final class ConfigurationTest extends TestCase
         Configuration::fromArray([
             'layers' => [
                 [
-                   'name' => 'foo',
-                   'collectors' => [],
+                    'name' => 'foo',
+                    'collectors' => [],
                 ],
                 [
-                   'name' => 'bar',
-                   'collectors' => [],
+                    'name' => 'bar',
+                    'collectors' => [],
                 ],
                 [
-                   'name' => 'baz',
-                   'collectors' => [],
+                    'name' => 'baz',
+                    'collectors' => [],
                 ],
             ],
             'paths' => [
@@ -98,16 +98,16 @@ final class ConfigurationTest extends TestCase
         $configuration = Configuration::fromArray([
             'layers' => [
                 [
-                   'name' => 'some_name',
-                   'collectors' => [],
+                    'name' => 'some_name',
+                    'collectors' => [],
                 ],
                 [
-                   'name' => 'xx',
-                   'collectors' => [],
+                    'name' => 'xx',
+                    'collectors' => [],
                 ],
                 [
-                   'name' => 'yy',
-                   'collectors' => [],
+                    'name' => 'yy',
+                    'collectors' => [],
                 ],
             ],
             'paths' => [
@@ -136,12 +136,12 @@ final class ConfigurationTest extends TestCase
         $configuration = Configuration::fromArray([
             'layers' => [
                 [
-                   'name' => 'some_name',
-                   'collectors' => [],
+                    'name' => 'some_name',
+                    'collectors' => [],
                 ],
                 [
-                   'name' => 'some_other_name',
-                   'collectors' => [],
+                    'name' => 'some_other_name',
+                    'collectors' => [],
                 ],
             ],
             'paths' => [

--- a/tests/Configuration/LoaderTest.php
+++ b/tests/Configuration/LoaderTest.php
@@ -4,11 +4,11 @@ declare(strict_types=1);
 
 namespace Tests\Qossmic\Deptrac\Configuration;
 
-use function array_map;
 use PHPUnit\Framework\TestCase;
 use Qossmic\Deptrac\Configuration\Loader;
 use Qossmic\Deptrac\Exception\File\CouldNotReadFileException;
 use Symfony\Component\Filesystem\Path;
+use function array_map;
 
 /**
  * @covers \Qossmic\Deptrac\Configuration\Loader

--- a/tests/Console/ServiceContainerBuilderTest.php
+++ b/tests/Console/ServiceContainerBuilderTest.php
@@ -4,7 +4,6 @@ declare(strict_types=1);
 
 namespace Tests\Qossmic\Deptrac\Console;
 
-use const DIRECTORY_SEPARATOR;
 use PHPUnit\Framework\TestCase;
 use Qossmic\Deptrac\AstRunner\AstParser\Cache\AstFileReferenceCacheInterface;
 use Qossmic\Deptrac\AstRunner\AstParser\Cache\AstFileReferenceDeferredCacheInterface;
@@ -12,6 +11,7 @@ use Qossmic\Deptrac\AstRunner\AstParser\Cache\AstFileReferenceFileCache;
 use Qossmic\Deptrac\AstRunner\AstParser\Cache\AstFileReferenceInMemoryCache;
 use Qossmic\Deptrac\Collector\Registry;
 use Qossmic\Deptrac\Console\ServiceContainerBuilder;
+use const DIRECTORY_SEPARATOR;
 
 final class ServiceContainerBuilderTest extends TestCase
 {

--- a/tests/Exception/Configuration/FileCannotBeParsedAsYamlExceptionTest.php
+++ b/tests/Exception/Configuration/FileCannotBeParsedAsYamlExceptionTest.php
@@ -6,6 +6,7 @@ namespace Tests\Qossmic\Deptrac\Exception\Configuration;
 
 use PHPUnit\Framework\TestCase;
 use Qossmic\Deptrac\Exception\Configuration\FileCannotBeParsedAsYamlException;
+use RuntimeException;
 use Symfony\Component\Yaml\Exception\ParseException;
 
 /**
@@ -17,7 +18,7 @@ final class FileCannotBeParsedAsYamlExceptionTest extends TestCase
     {
         $exception = new FileCannotBeParsedAsYamlException();
 
-        self::assertInstanceOf(\RuntimeException::class, $exception);
+        self::assertInstanceOf(RuntimeException::class, $exception);
     }
 
     public function testFromFilenameAndExceptionReturnsException(): void

--- a/tests/Exception/Configuration/InvalidConfigurationExceptionTest.php
+++ b/tests/Exception/Configuration/InvalidConfigurationExceptionTest.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace Tests\Qossmic\Deptrac\Exception\Configuration;
 
+use InvalidArgumentException;
 use PHPUnit\Framework\TestCase;
 use Qossmic\Deptrac\Exception\Configuration\InvalidConfigurationException;
 
@@ -16,7 +17,7 @@ final class InvalidConfigurationExceptionTest extends TestCase
     {
         $exception = new InvalidConfigurationException();
 
-        self::assertInstanceOf(\InvalidArgumentException::class, $exception);
+        self::assertInstanceOf(InvalidArgumentException::class, $exception);
     }
 
     public function testFromDuplicateLayerNamesReturnsException(): void

--- a/tests/Exception/Configuration/ParsedYamlIsNotAnArrayExceptionTest.php
+++ b/tests/Exception/Configuration/ParsedYamlIsNotAnArrayExceptionTest.php
@@ -6,6 +6,7 @@ namespace Tests\Qossmic\Deptrac\Exception\Configuration;
 
 use PHPUnit\Framework\TestCase;
 use Qossmic\Deptrac\Exception\Configuration\ParsedYamlIsNotAnArrayException;
+use RuntimeException;
 
 /**
  * @covers \Qossmic\Deptrac\Exception\Configuration\ParsedYamlIsNotAnArrayException
@@ -16,7 +17,7 @@ final class ParsedYamlIsNotAnArrayExceptionTest extends TestCase
     {
         $exception = new ParsedYamlIsNotAnArrayException();
 
-        self::assertInstanceOf(\RuntimeException::class, $exception);
+        self::assertInstanceOf(RuntimeException::class, $exception);
     }
 
     public function testFromFilenameReturnsException(): void

--- a/tests/Exception/Console/InvalidArgumentExceptionTest.php
+++ b/tests/Exception/Console/InvalidArgumentExceptionTest.php
@@ -6,6 +6,7 @@ namespace Tests\Qossmic\Deptrac\Exception\Console;
 
 use PHPUnit\Framework\TestCase;
 use Qossmic\Deptrac\Exception\Console\InvalidArgumentException;
+use RuntimeException;
 
 /**
  * @covers \Qossmic\Deptrac\Exception\Console\InvalidArgumentException
@@ -16,7 +17,7 @@ final class InvalidArgumentExceptionTest extends TestCase
     {
         $exception = new InvalidArgumentException();
 
-        self::assertInstanceOf(\RuntimeException::class, $exception);
+        self::assertInstanceOf(RuntimeException::class, $exception);
     }
 
     public function provideUnepxectedTypes(): iterable

--- a/tests/Exception/File/CouldNotReadFileExceptionTest.php
+++ b/tests/Exception/File/CouldNotReadFileExceptionTest.php
@@ -6,6 +6,7 @@ namespace Tests\Qossmic\Deptrac\Exception\File;
 
 use PHPUnit\Framework\TestCase;
 use Qossmic\Deptrac\Exception\File\CouldNotReadFileException;
+use RuntimeException;
 
 /**
  * @covers \Qossmic\Deptrac\Exception\File\CouldNotReadFileException
@@ -16,7 +17,7 @@ final class CouldNotReadFileExceptionTest extends TestCase
     {
         $exception = new CouldNotReadFileException();
 
-        self::assertInstanceOf(\RuntimeException::class, $exception);
+        self::assertInstanceOf(RuntimeException::class, $exception);
     }
 
     public function testFromFilenameReturnsException(): void

--- a/tests/OutputFormatter/GraphVizDotOutputFormatterTest.php
+++ b/tests/OutputFormatter/GraphVizDotOutputFormatterTest.php
@@ -69,10 +69,10 @@ final class GraphVizDotOutputFormatterTest extends TestCase
         );
 
         $context = new Context([
-                new Allowed($dependency, 'User Frontend', 'User Backend'),
-                new Allowed($dependency, 'Admin', 'Admin Backend'),
-                new Allowed($dependency, 'User Frontend', 'Admin'),
-                new Allowed($dependency, 'User Backend', 'Admin'),
+            new Allowed($dependency, 'User Frontend', 'User Backend'),
+            new Allowed($dependency, 'Admin', 'Admin Backend'),
+            new Allowed($dependency, 'User Frontend', 'Admin'),
+            new Allowed($dependency, 'User Backend', 'Admin'),
         ], [], []);
 
         $bufferedOutput = new BufferedOutput();
@@ -114,11 +114,11 @@ final class GraphVizDotOutputFormatterTest extends TestCase
         );
 
         $context = new Context([
-                                   new Allowed($dependency, 'User Frontend', 'User Backend'),
-                                   new Allowed($dependency, 'Admin', 'Admin Backend'),
-                                   new Allowed($dependency, 'User Frontend', 'Admin'),
-                                   new Allowed($dependency, 'User Backend', 'Admin'),
-                               ], [], []);
+            new Allowed($dependency, 'User Frontend', 'User Backend'),
+            new Allowed($dependency, 'Admin', 'Admin Backend'),
+            new Allowed($dependency, 'User Frontend', 'Admin'),
+            new Allowed($dependency, 'User Backend', 'Admin'),
+        ], [], []);
 
         $bufferedOutput = new BufferedOutput();
         $input = new OutputFormatterInput(

--- a/tests/OutputFormatterFactoryTest.php
+++ b/tests/OutputFormatterFactoryTest.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace Tests\Qossmic\Deptrac;
 
+use LogicException;
 use PHPUnit\Framework\TestCase;
 use Qossmic\Deptrac\OutputFormatter\ConsoleOutputFormatter;
 use Qossmic\Deptrac\OutputFormatter\TableOutputFormatter;
@@ -24,7 +25,7 @@ final class OutputFormatterFactoryTest extends TestCase
 
     public function testGetFormatterByNameNotFound(): void
     {
-        $this->expectException(\LogicException::class);
+        $this->expectException(LogicException::class);
 
         (new OutputFormatterFactory([]))->getFormatterByName('formatter1');
     }

--- a/tests/PathNameFilterIteratorTest.php
+++ b/tests/PathNameFilterIteratorTest.php
@@ -5,22 +5,24 @@ declare(strict_types=1);
 namespace Tests\Qossmic\Deptrac;
 
 use ArrayIterator;
+use Iterator;
 use PHPUnit\Framework\TestCase;
 use Qossmic\Deptrac\PathNameFilterIterator;
 use SplFileInfo;
+use const DIRECTORY_SEPARATOR;
 
 final class PathNameFilterIteratorTest extends TestCase
 {
     /**
      * @dataProvider getTestFilterData
      */
-    public function testFilter(\Iterator $inner, array $matchPatterns, array $noMatchPatterns, array $resultArray): void
+    public function testFilter(Iterator $inner, array $matchPatterns, array $noMatchPatterns, array $resultArray): void
     {
         $iterator = new PathNameFilterIterator($inner, $matchPatterns, $noMatchPatterns);
 
         $values = array_map(
             static function (SplFileInfo $fileInfo) {
-                return str_replace('/', \DIRECTORY_SEPARATOR, $fileInfo->getPathname());
+                return str_replace('/', DIRECTORY_SEPARATOR, $fileInfo->getPathname());
             },
             iterator_to_array($iterator, false)
         );
@@ -37,27 +39,27 @@ final class PathNameFilterIteratorTest extends TestCase
 
         //PATH:   A/B/C/abc.dat
         $inner[] = new SplFileInfo(
-            'A'.\DIRECTORY_SEPARATOR.'B'.\DIRECTORY_SEPARATOR.'C'.\DIRECTORY_SEPARATOR.'abc.dat'
+            'A'.DIRECTORY_SEPARATOR.'B'.DIRECTORY_SEPARATOR.'C'.DIRECTORY_SEPARATOR.'abc.dat'
         );
 
         //PATH:   A/B/ab.dat
-        $inner[] = new SplFileInfo('A'.\DIRECTORY_SEPARATOR.'B'.\DIRECTORY_SEPARATOR.'ab.dat');
+        $inner[] = new SplFileInfo('A'.DIRECTORY_SEPARATOR.'B'.DIRECTORY_SEPARATOR.'ab.dat');
 
         //PATH:   A/a.dat
-        $inner[] = new SplFileInfo('A'.\DIRECTORY_SEPARATOR.'a.dat');
+        $inner[] = new SplFileInfo('A'.DIRECTORY_SEPARATOR.'a.dat');
 
         //PATH:   copy/A/B/C/abc.dat.copy
         $inner[] = new SplFileInfo(
-            'copy'.\DIRECTORY_SEPARATOR.'A'.\DIRECTORY_SEPARATOR.'B'.\DIRECTORY_SEPARATOR.'C'.\DIRECTORY_SEPARATOR.'abc.dat.copy'
+            'copy'.DIRECTORY_SEPARATOR.'A'.DIRECTORY_SEPARATOR.'B'.DIRECTORY_SEPARATOR.'C'.DIRECTORY_SEPARATOR.'abc.dat.copy'
         );
 
         //PATH:   copy/A/B/ab.dat.copy
         $inner[] = new SplFileInfo(
-            'copy'.\DIRECTORY_SEPARATOR.'A'.\DIRECTORY_SEPARATOR.'B'.\DIRECTORY_SEPARATOR.'ab.dat.copy'
+            'copy'.DIRECTORY_SEPARATOR.'A'.DIRECTORY_SEPARATOR.'B'.DIRECTORY_SEPARATOR.'ab.dat.copy'
         );
 
         //PATH:   copy/A/a.dat.copy
-        $inner[] = new SplFileInfo('copy'.\DIRECTORY_SEPARATOR.'A'.\DIRECTORY_SEPARATOR.'a.dat.copy');
+        $inner[] = new SplFileInfo('copy'.DIRECTORY_SEPARATOR.'A'.DIRECTORY_SEPARATOR.'a.dat.copy');
 
         return [
             [$inner, ['/^A/'], [], ['A/B/C/abc.dat', 'A/B/ab.dat', 'A/a.dat']],

--- a/tests/RulesetEngine/SkippedViolationHelperTest.php
+++ b/tests/RulesetEngine/SkippedViolationHelperTest.php
@@ -13,16 +13,16 @@ final class SkippedViolationHelperTest extends TestCase
     public function testIsViolationSkipped(): void
     {
         $configuration = [
-                'ClassWithOneDep' => [
-                    'DependencyClass',
-                ],
-                'ClassWithEmptyDeps' => [],
-                'ClassWithMultipleDeps' => [
-                    'DependencyClass1',
-                    'DependencyClass2',
-                    'DependencyClass2',
-                ],
-            ];
+            'ClassWithOneDep' => [
+                'DependencyClass',
+            ],
+            'ClassWithEmptyDeps' => [],
+            'ClassWithMultipleDeps' => [
+                'DependencyClass1',
+                'DependencyClass2',
+                'DependencyClass2',
+            ],
+        ];
         $helper = new SkippedViolationHelper($configuration);
 
         self::assertTrue(
@@ -54,16 +54,16 @@ final class SkippedViolationHelperTest extends TestCase
     public function testUnmatchedSkippedViolations(): void
     {
         $configuration = [
-                'ClassWithOneDep' => [
-                    'DependencyClass',
-                ],
-                'ClassWithEmptyDeps' => [],
-                'ClassWithMultipleDeps' => [
-                    'DependencyClass1',
-                    'DependencyClass2',
-                    'DependencyClass2',
-                ],
-            ];
+            'ClassWithOneDep' => [
+                'DependencyClass',
+            ],
+            'ClassWithEmptyDeps' => [],
+            'ClassWithMultipleDeps' => [
+                'DependencyClass1',
+                'DependencyClass2',
+                'DependencyClass2',
+            ],
+        ];
         $helper = new SkippedViolationHelper($configuration);
 
         self::assertTrue(

--- a/tests/TokenLayerResolverTest.php
+++ b/tests/TokenLayerResolverTest.php
@@ -15,6 +15,7 @@ use Qossmic\Deptrac\Configuration\Configuration;
 use Qossmic\Deptrac\Configuration\ConfigurationLayer;
 use Qossmic\Deptrac\Configuration\ParameterResolver;
 use Qossmic\Deptrac\TokenLayerResolver;
+use RuntimeException;
 
 final class TokenLayerResolverTest extends TestCase
 {
@@ -127,7 +128,7 @@ final class TokenLayerResolverTest extends TestCase
 
     public function testCircularDependency(): void
     {
-        $this->expectException(\RuntimeException::class);
+        $this->expectException(RuntimeException::class);
         $this->expectExceptionMessage('Circular dependency between layers detected');
 
         $configuration = $this->createMock(Configuration::class);


### PR DESCRIPTION
I was annoyed by the (for my taste) weirdly arranged use statements and some minor inconsistencies, so I updated the rules. Sorry, if this causes some inconvenience for open PRs.

Updated rules:
 * Ensure consistent array indentation
 * Always import not classes, functions and constants
 * Rearrange use statements by group (class, function, const)
 * ~~use modern string methods like `str_starts_with` when possible~~ We don't have Symfony's polyfill and I don't want to add it for the 1 change caused by this rule
 * use octal notation