### PR TITLE
Fix Invalid type for path "deptrac.parameters.analyzer".

### DIFF
--- a/src/Configuration/Loader.php
+++ b/src/Configuration/Loader.php
@@ -99,6 +99,7 @@ class Loader
             'ruleset' => $this->normalizeValue($config, 'ruleset', $filename),
             'skip_violations' => $this->normalizeValue($config, 'skip_violations', $filename),
             'analyser' => $this->normalizeValue($config, 'analyser', $filename),
+            'analyzer' => $this->normalizeValue($config, 'analyzer', $filename),
             'ignore_uncovered_internal_classes' => $this->normalizeValue($config, 'ignore_uncovered_internal_classes', $filename),
         ];
 


### PR DESCRIPTION
Fixes #766

No test, because this section is deprecated anyway and I'm planning on removing it in the release after the next one.