### PR TITLE
Refactor of TokenLayerResolver

### DIFF
--- a/baseline.xml
+++ b/baseline.xml
@@ -187,7 +187,7 @@
   </file>
   <file src="src/TokenLayerResolver.php">
     <ArgumentTypeCoercion occurrences="1">
-      <code>$this-&gt;parameterResolver-&gt;resolve($configurationLayer-&gt;toArray(), $this-&gt;configuration-&gt;getParameters())</code>
+      <code>$parameterResolver-&gt;resolve($configurationLayer-&gt;toArray(), $configuration-&gt;getParameters())</code>
     </ArgumentTypeCoercion>
   </file>
 </files>

--- a/depfile.baseline.yml
+++ b/depfile.baseline.yml
@@ -24,6 +24,7 @@ skip_violations:
     - Qossmic\Deptrac\AstRunner\AstMap\AstClassReference
     - Qossmic\Deptrac\AstRunner\AstMap\AstFileReference
     - Qossmic\Deptrac\AstRunner\AstMap\AstFunctionReference
+    - Qossmic\Deptrac\AstRunner\AstMap\AstTokenReference
     - Qossmic\Deptrac\AstRunner\AstMap\AstVariableReference
   Qossmic\Deptrac\TokenLayerResolverFactory:
     - Qossmic\Deptrac\AstRunner\AstMap

--- a/src/Collector/BoolCollector.php
+++ b/src/Collector/BoolCollector.php
@@ -20,7 +20,7 @@ class BoolCollector implements CollectorInterface
         AstMap\AstTokenReference $astTokenReference,
         AstMap $astMap,
         Registry $collectorRegistry,
-        array $allLayersConfiguration = []
+        array $resolutionTable = []
     ): bool {
         $configuration = $this->normalizeConfiguration($configuration);
 
@@ -33,7 +33,7 @@ class BoolCollector implements CollectorInterface
                 $astTokenReference,
                 $astMap,
                 $collectorRegistry,
-                $allLayersConfiguration
+                $resolutionTable
             )) {
                 return false;
             }
@@ -48,7 +48,7 @@ class BoolCollector implements CollectorInterface
                 $astTokenReference,
                 $astMap,
                 $collectorRegistry,
-                $allLayersConfiguration
+                $resolutionTable
             )) {
                 return false;
             }
@@ -57,14 +57,14 @@ class BoolCollector implements CollectorInterface
         return true;
     }
 
-    public function resolvable(array $configuration, Registry $collectorRegistry, array $alreadyResolvedLayers): bool
+    public function resolvable(array $configuration, Registry $collectorRegistry, array $resolutionTable): bool
     {
         $configuration = $this->normalizeConfiguration($configuration);
         /** @var array<string, string> $v */
         foreach ((array) $configuration['must'] as $v) {
             $configurationForCollector = ConfigurationCollector::fromArray($v);
             if (!$collectorRegistry->getCollector($configurationForCollector->getType())->resolvable(
-                $configurationForCollector->getArgs(), $collectorRegistry, $alreadyResolvedLayers
+                $configurationForCollector->getArgs(), $collectorRegistry, $resolutionTable
             )) {
                 return false;
             }
@@ -73,7 +73,7 @@ class BoolCollector implements CollectorInterface
         foreach ((array) $configuration['must_not'] as $v) {
             $configurationForCollector = ConfigurationCollector::fromArray($v);
             if (!$collectorRegistry->getCollector($configurationForCollector->getType())->resolvable(
-                $configurationForCollector->getArgs(), $collectorRegistry, $alreadyResolvedLayers
+                $configurationForCollector->getArgs(), $collectorRegistry, $resolutionTable
             )) {
                 return false;
             }

--- a/src/Collector/ClassNameCollector.php
+++ b/src/Collector/ClassNameCollector.php
@@ -20,7 +20,7 @@ class ClassNameCollector extends RegexCollector implements CollectorInterface
         AstMap\AstTokenReference $astTokenReference,
         AstMap $astMap,
         Registry $collectorRegistry,
-        array $allLayersConfiguration = []
+        array $resolutionTable = []
     ): bool {
         if (!$astTokenReference instanceof AstClassReference) {
             return false;

--- a/src/Collector/ClassNameRegexCollector.php
+++ b/src/Collector/ClassNameRegexCollector.php
@@ -20,7 +20,7 @@ class ClassNameRegexCollector extends RegexCollector implements CollectorInterfa
         AstMap\AstTokenReference $astTokenReference,
         AstMap $astMap,
         Registry $collectorRegistry,
-        array $allLayersConfiguration = []
+        array $resolutionTable = []
     ): bool {
         if (!$astTokenReference instanceof AstClassReference) {
             return false;

--- a/src/Collector/CollectorInterface.php
+++ b/src/Collector/CollectorInterface.php
@@ -5,7 +5,6 @@ declare(strict_types=1);
 namespace Qossmic\Deptrac\Collector;
 
 use Qossmic\Deptrac\AstRunner\AstMap;
-use Qossmic\Deptrac\Configuration\ConfigurationLayer;
 
 /**
  * A collector is responsible to tell from an AST node (e.g. a specific class) is part of a layer.
@@ -22,9 +21,9 @@ interface CollectorInterface
     public function getType(): string;
 
     /**
-     * @param array<string, string|array> $configuration          List of arguments passed for this collector declaration
-     * @param AstMap\AstTokenReference    $astTokenReference      Token being checked
-     * @param ConfigurationLayer[]        $allLayersConfiguration
+     * @param array<string, string|array> $configuration     List of arguments passed for this collector declaration
+     * @param AstMap\AstTokenReference    $astTokenReference Token being checked
+     * @param array<string, ?bool>        $resolutionTable   layer name => is part of the layer? (NULL = Unknown)
      *
      * @example
      *  For the YAML configuration:
@@ -44,8 +43,11 @@ interface CollectorInterface
         AstMap\AstTokenReference $astTokenReference,
         AstMap $astMap,
         Registry $collectorRegistry,
-        array $allLayersConfiguration = []
+        array $resolutionTable = []
     ): bool;
 
-    public function resolvable(array $configuration, Registry $collectorRegistry, array $alreadyResolvedLayers): bool;
+    /**
+     * @param array<string, ?bool> $resolutionTable layer name => is part of the layer? (NULL = Unknown)
+     */
+    public function resolvable(array $configuration, Registry $collectorRegistry, array $resolutionTable): bool;
 }

--- a/src/Collector/DirectoryCollector.php
+++ b/src/Collector/DirectoryCollector.php
@@ -20,7 +20,7 @@ class DirectoryCollector extends RegexCollector implements CollectorInterface
         AstMap\AstTokenReference $astTokenReference,
         AstMap $astMap,
         Registry $collectorRegistry,
-        array $allLayersConfiguration = []
+        array $resolutionTable = []
     ): bool {
         $fileReference = $astTokenReference->getFileReference();
 

--- a/src/Collector/ExtendsCollector.php
+++ b/src/Collector/ExtendsCollector.php
@@ -19,7 +19,7 @@ class ExtendsCollector implements CollectorInterface
         return 'extends';
     }
 
-    public function resolvable(array $configuration, Registry $collectorRegistry, array $alreadyResolvedLayers): bool
+    public function resolvable(array $configuration, Registry $collectorRegistry, array $resolutionTable): bool
     {
         return true;
     }
@@ -32,7 +32,7 @@ class ExtendsCollector implements CollectorInterface
         AstMap\AstTokenReference $astTokenReference,
         AstMap $astMap,
         Registry $collectorRegistry,
-        array $allLayersConfiguration = []
+        array $resolutionTable = []
     ): bool {
         if (!$astTokenReference instanceof AstClassReference) {
             return false;

--- a/src/Collector/FunctionNameCollector.php
+++ b/src/Collector/FunctionNameCollector.php
@@ -14,7 +14,7 @@ class FunctionNameCollector implements CollectorInterface
         return 'functionName';
     }
 
-    public function resolvable(array $configuration, Registry $collectorRegistry, array $alreadyResolvedLayers): bool
+    public function resolvable(array $configuration, Registry $collectorRegistry, array $resolutionTable): bool
     {
         return true;
     }
@@ -24,7 +24,7 @@ class FunctionNameCollector implements CollectorInterface
         AstMap\AstTokenReference $astTokenReference,
         AstMap $astMap,
         Registry $collectorRegistry,
-        array $allLayersConfiguration = []
+        array $resolutionTable = []
     ): bool {
         if (!$astTokenReference instanceof AstMap\AstFunctionReference) {
             return false;

--- a/src/Collector/ImplementsCollector.php
+++ b/src/Collector/ImplementsCollector.php
@@ -19,7 +19,7 @@ class ImplementsCollector implements CollectorInterface
         return 'implements';
     }
 
-    public function resolvable(array $configuration, Registry $collectorRegistry, array $alreadyResolvedLayers): bool
+    public function resolvable(array $configuration, Registry $collectorRegistry, array $resolutionTable): bool
     {
         return true;
     }
@@ -32,7 +32,7 @@ class ImplementsCollector implements CollectorInterface
         AstMap\AstTokenReference $astTokenReference,
         AstMap $astMap,
         Registry $collectorRegistry,
-        array $allLayersConfiguration = []
+        array $resolutionTable = []
     ): bool {
         if (!$astTokenReference instanceof AstClassReference) {
             return false;

--- a/src/Collector/InheritanceLevelCollector.php
+++ b/src/Collector/InheritanceLevelCollector.php
@@ -14,7 +14,7 @@ class InheritanceLevelCollector implements CollectorInterface
         return 'inheritanceLevel';
     }
 
-    public function resolvable(array $configuration, Registry $collectorRegistry, array $alreadyResolvedLayers): bool
+    public function resolvable(array $configuration, Registry $collectorRegistry, array $resolutionTable): bool
     {
         return true;
     }
@@ -24,7 +24,7 @@ class InheritanceLevelCollector implements CollectorInterface
         AstMap\AstTokenReference $astTokenReference,
         AstMap $astMap,
         Registry $collectorRegistry,
-        array $allLayersConfiguration = []
+        array $resolutionTable = []
     ): bool {
         if (!$astTokenReference instanceof AstClassReference) {
             return false;

--- a/src/Collector/InheritsCollector.php
+++ b/src/Collector/InheritsCollector.php
@@ -19,7 +19,7 @@ class InheritsCollector implements CollectorInterface
         return 'inherits';
     }
 
-    public function resolvable(array $configuration, Registry $collectorRegistry, array $alreadyResolvedLayers): bool
+    public function resolvable(array $configuration, Registry $collectorRegistry, array $resolutionTable): bool
     {
         return true;
     }
@@ -32,7 +32,7 @@ class InheritsCollector implements CollectorInterface
         AstMap\AstTokenReference $astTokenReference,
         AstMap $astMap,
         Registry $collectorRegistry,
-        array $allLayersConfiguration = []
+        array $resolutionTable = []
     ): bool {
         if (!$astTokenReference instanceof AstClassReference) {
             return false;

--- a/src/Collector/LayerCollector.php
+++ b/src/Collector/LayerCollector.php
@@ -19,35 +19,25 @@ class LayerCollector implements CollectorInterface
         AstMap\AstTokenReference $astTokenReference,
         AstMap $astMap,
         Registry $collectorRegistry,
-        array $allLayersConfiguration = []
+        array $resolutionTable = []
     ): bool {
         if (!isset($configuration['layer']) || !is_string($configuration['layer'])) {
             throw new InvalidArgumentException('LayerCollector needs the layer configuration.');
         }
-        if (!array_key_exists($configuration['layer'], $allLayersConfiguration)) {
+        if (!array_key_exists($configuration['layer'], $resolutionTable)) {
             throw new InvalidArgumentException('Referenced layer in LayerCollector does not exist.');
         }
 
-        $layerConfig = $allLayersConfiguration[$configuration['layer']];
+        /** @var bool $result */
+        $result = $resolutionTable[$configuration['layer']];
 
-        foreach ($layerConfig->getCollectors() as $configurationForCollector) {
-            if ($collectorRegistry->getCollector($configurationForCollector->getType())
-                ->satisfy(
-                    $configurationForCollector->getArgs(),
-                    $astTokenReference,
-                    $astMap,
-                    $collectorRegistry,
-                    $allLayersConfiguration
-                )) {
-                return true;
-            }
-        }
-
-        return false;
+        return $result;
     }
 
-    public function resolvable(array $configuration, Registry $collectorRegistry, array $alreadyResolvedLayers): bool
+    public function resolvable(array $configuration, Registry $collectorRegistry, array $resolutionTable): bool
     {
-        return in_array($configuration['layer'], $alreadyResolvedLayers, true);
+        $key = (string) $configuration['layer'];
+
+        return array_key_exists($key, $resolutionTable) && null !== $resolutionTable[$key];
     }
 }

--- a/src/Collector/MethodCollector.php
+++ b/src/Collector/MethodCollector.php
@@ -28,7 +28,7 @@ class MethodCollector extends RegexCollector implements CollectorInterface
         AstMap\AstTokenReference $astTokenReference,
         AstMap $astMap,
         Registry $collectorRegistry,
-        array $allLayersConfiguration = []
+        array $resolutionTable = []
     ): bool {
         if (!$astTokenReference instanceof AstClassReference) {
             return false;

--- a/src/Collector/RegexCollector.php
+++ b/src/Collector/RegexCollector.php
@@ -13,7 +13,7 @@ abstract class RegexCollector
      */
     abstract protected function getPattern(array $configuration): string;
 
-    public function resolvable(array $configuration, Registry $collectorRegistry, array $alreadyResolvedLayers): bool
+    public function resolvable(array $configuration, Registry $collectorRegistry, array $resolutionTable): bool
     {
         return true;
     }

--- a/src/Collector/SuperglobalCollector.php
+++ b/src/Collector/SuperglobalCollector.php
@@ -14,7 +14,7 @@ class SuperglobalCollector implements CollectorInterface
         return 'superglobal';
     }
 
-    public function resolvable(array $configuration, Registry $collectorRegistry, array $alreadyResolvedLayers): bool
+    public function resolvable(array $configuration, Registry $collectorRegistry, array $resolutionTable): bool
     {
         return true;
     }
@@ -24,7 +24,7 @@ class SuperglobalCollector implements CollectorInterface
         AstMap\AstTokenReference $astTokenReference,
         AstMap $astMap,
         Registry $collectorRegistry,
-        array $allLayersConfiguration = []
+        array $resolutionTable = []
     ): bool {
         if (!$astTokenReference instanceof AstMap\AstVariableReference) {
             return false;

--- a/src/Collector/UsesCollector.php
+++ b/src/Collector/UsesCollector.php
@@ -19,7 +19,7 @@ class UsesCollector implements CollectorInterface
         return 'uses';
     }
 
-    public function resolvable(array $configuration, Registry $collectorRegistry, array $alreadyResolvedLayers): bool
+    public function resolvable(array $configuration, Registry $collectorRegistry, array $resolutionTable): bool
     {
         return true;
     }
@@ -32,7 +32,7 @@ class UsesCollector implements CollectorInterface
         AstMap\AstTokenReference $astTokenReference,
         AstMap $astMap,
         Registry $collectorRegistry,
-        array $allLayersConfiguration = []
+        array $resolutionTable = []
     ): bool {
         if (!$astTokenReference instanceof AstClassReference) {
             return false;

--- a/src/TokenLayerResolver.php
+++ b/src/TokenLayerResolver.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace Qossmic\Deptrac;
 
 use Qossmic\Deptrac\AstRunner\AstMap;
+use Qossmic\Deptrac\AstRunner\AstMap\AstTokenReference;
 use Qossmic\Deptrac\AstRunner\AstMap\ClassLikeName;
 use Qossmic\Deptrac\Collector\Registry;
 use Qossmic\Deptrac\Configuration\Configuration;
@@ -15,10 +16,11 @@ use RuntimeException;
 
 class TokenLayerResolver implements TokenLayerResolverInterface
 {
-    private Configuration $configuration;
     private AstMap $astMap;
     private Registry $collectorRegistry;
-    private ParameterResolver $parameterResolver;
+
+    /** @var ConfigurationLayer[] */
+    private array $resolvedLayerConfiguration;
 
     public function __construct(
         Configuration $configuration,
@@ -26,10 +28,16 @@ class TokenLayerResolver implements TokenLayerResolverInterface
         Registry $collectorRegistry,
         ParameterResolver $parameterResolver
     ) {
-        $this->configuration = $configuration;
         $this->astMap = $astMap;
         $this->collectorRegistry = $collectorRegistry;
-        $this->parameterResolver = $parameterResolver;
+        $this->resolvedLayerConfiguration = array_map(static function (ConfigurationLayer $configurationLayer) use (
+            $configuration,
+            $parameterResolver
+        ): ConfigurationLayer {
+            return ConfigurationLayer::fromArray(
+                $parameterResolver->resolve($configurationLayer->toArray(), $configuration->getParameters())
+            );
+        }, $configuration->getLayers());
     }
 
     /**
@@ -37,74 +45,100 @@ class TokenLayerResolver implements TokenLayerResolverInterface
      */
     public function getLayersByTokenName(AstMap\TokenName $tokenName): array
     {
+        $astTokenReference = $this->getAstTokenReference($tokenName);
+
+        $layerResolvers = $this->layerResolvers();
+        $layerNames = array_map(static fn (ConfigurationLayer $config): string => $config->getName(), $this->resolvedLayerConfiguration);
+        /** @var array<string, null> $resolutionTable */
+        $resolutionTable = array_combine($layerNames, array_map(static fn ($_) => null, $layerNames));
+        $remainingToResolve = count(array_filter($resolutionTable, static fn (?bool $status): bool => null === $status));
+        while ($remainingToResolve > 0) {
+            foreach ($resolutionTable as $layerName => $isResolved) {
+                if (null === $isResolved) {
+                    $resolutionTable[$layerName] = $layerResolvers[$layerName]($astTokenReference, array_keys(array_filter($resolutionTable, static fn (?bool $status): bool => null !== $status)));
+                }
+            }
+            $nowRemaining = count(array_filter($resolutionTable, static fn (?bool $status): bool => null === $status));
+            if ($nowRemaining === $remainingToResolve) {
+                throw new RuntimeException('Circular dependency between layers detected');
+            }
+            $remainingToResolve = $nowRemaining;
+        }
+
+        return array_keys(array_filter($resolutionTable));
+    }
+
+    private function getAstTokenReference(AstMap\TokenName $tokenName): AstTokenReference
+    {
         if ($tokenName instanceof ClassLikeName) {
             if (!$astTokenReference = $this->astMap->getClassReferenceByClassName($tokenName)) {
                 $astTokenReference = new AstMap\AstClassReference($tokenName);
             }
-        } elseif ($tokenName instanceof AstMap\FunctionName) {
+
+            return $astTokenReference;
+        }
+
+        if ($tokenName instanceof AstMap\FunctionName) {
             if (!$astTokenReference = $this->astMap->getFunctionReferenceByFunctionName($tokenName)) {
                 $astTokenReference = new AstMap\AstFunctionReference($tokenName);
             }
-        } elseif ($tokenName instanceof AstMap\FileName) {
+
+            return $astTokenReference;
+        }
+
+        if ($tokenName instanceof AstMap\FileName) {
             if (!$astTokenReference = $this->astMap->getFileReferenceByFileName($tokenName)) {
                 $astTokenReference = new AstMap\AstFileReference($tokenName->getFilepath(), [], [], []);
             }
-        } elseif ($tokenName instanceof AstMap\SuperGlobalName) {
-            $astTokenReference = new AstMap\AstVariableReference($tokenName);
-        } else {
-            throw new ShouldNotHappenException();
+
+            return $astTokenReference;
         }
 
-        /** @var array<string, bool> $layers */
-        $layers = [];
+        if ($tokenName instanceof AstMap\SuperGlobalName) {
+            return new AstMap\AstVariableReference($tokenName);
+        }
 
-        $layerRegistry = [];
-        $numberOfLayersToResolve = count($this->configuration->getLayers());
-        $resolvedBeforeLoop = 0;
-        $resolvedLayerConfiguration = $this->getResolvedLayerConfiguration();
-        while (count($layerRegistry) < $numberOfLayersToResolve) {
-            foreach ($resolvedLayerConfiguration as $configurationLayer) {
-                foreach ($configurationLayer->getCollectors() as $configurationCollector) {
-                    $collector = $this->collectorRegistry->getCollector($configurationCollector->getType());
+        throw new ShouldNotHappenException();
+    }
 
-                    if ($collector->resolvable($configurationCollector->getArgs(), $this->collectorRegistry, $layerRegistry)) {
+    /**
+     * @return array<string, callable(AstTokenReference, array<string>): ?bool>
+     */
+    private function layerResolvers(): array
+    {
+        $layerResolvers = [];
+        foreach ($this->resolvedLayerConfiguration as $configurationLayer) {
+            $layerResolvers[$configurationLayer->getName()] =
+                function (AstTokenReference $astTokenReference, array $alreadyResolvedLayers) use (
+                    $configurationLayer
+                ): ?bool {
+                    foreach ($configurationLayer->getCollectors() as $configurationCollector) {
+                        $collector = $this->collectorRegistry->getCollector($configurationCollector->getType());
+                        if (!$collector->resolvable(
+                            $configurationCollector->getArgs(),
+                            $this->collectorRegistry,
+                            $alreadyResolvedLayers
+                        )
+                        ) {
+                            return null;
+                        }
+
                         if ($collector->satisfy(
                             $configurationCollector->toArray(),
                             $astTokenReference,
                             $this->astMap,
                             $this->collectorRegistry,
-                            $resolvedLayerConfiguration
+                            $this->resolvedLayerConfiguration
                         )
                         ) {
-                            $layers[$configurationLayer->getName()] = true;
+                            return true;
                         }
-                    } else {
-                        continue 2;
                     }
-                }
-                $layerRegistry[] = $configurationLayer->getName();
-            }
-            if ($resolvedBeforeLoop === count($layerRegistry)) {
-                throw new RuntimeException('Circular dependency between layers detected');
-            }
-            $resolvedBeforeLoop = count($layerRegistry);
+
+                    return false;
+                };
         }
 
-        /** @var string[] $layerNames */
-        $layerNames = array_keys($layers);
-
-        return $layerNames;
-    }
-
-    /**
-     * @return ConfigurationLayer[]
-     */
-    private function getResolvedLayerConfiguration(): array
-    {
-        return array_map(function (ConfigurationLayer $configurationLayer): ConfigurationLayer {
-            return ConfigurationLayer::fromArray(
-                $this->parameterResolver->resolve($configurationLayer->toArray(), $this->configuration->getParameters())
-            );
-        }, $this->configuration->getLayers());
+        return $layerResolvers;
     }
 }

--- a/tests/Collector/LayerCollectorTest.php
+++ b/tests/Collector/LayerCollectorTest.php
@@ -38,7 +38,7 @@ final class LayerCollectorTest extends TestCase
         $resolved = (new LayerCollector())->resolvable(
             ['layer' => 'test'],
             $this->createMock(Registry::class),
-            ['test', 'somethingElse']
+            ['test' => false, 'somethingElse' => true]
         );
         self::assertEquals(true, $resolved);
     }
@@ -72,7 +72,7 @@ final class LayerCollectorTest extends TestCase
             new AstClassReference(AstMap\ClassLikeName::fromFQCN($className)),
             $this->createMock(AstMap::class),
             $collectorRegistry,
-            $configuration
+            [$configuration['otherLayer']->getName() => $expected]
         );
 
         self::assertEquals($expected, $resolved);

--- a/tests/Console/DummyCollector.php
+++ b/tests/Console/DummyCollector.php
@@ -18,12 +18,12 @@ class DummyCollector implements CollectorInterface
         AstMap\AstTokenReference $astTokenReference,
         AstMap $astMap,
         Registry $collectorRegistry,
-        array $allLayersConfiguration = []
+        array $resolutionTable = []
     ): bool {
         return true;
     }
 
-    public function resolvable(array $configuration, Registry $collectorRegistry, array $alreadyResolvedLayers): bool
+    public function resolvable(array $configuration, Registry $collectorRegistry, array $resolutionTable): bool
     {
         return true;
     }


### PR DESCRIPTION
To make each layer resolution only once and then use that result in collectors that need it. Instead of making the collectors resolve the layers again.