### PR TITLE
Fix 758

### DIFF
--- a/src/AstRunner/AstMap.php
+++ b/src/AstRunner/AstMap.php
@@ -55,6 +55,14 @@ class AstMap
         return $this->astFileReferences;
     }
 
+    /**
+     * @return AstFunctionReference[]
+     */
+    public function getAstFunctionReferences(): array
+    {
+        return $this->astFunctionReferences;
+    }
+
     public function getClassReferenceByClassName(ClassLikeName $className): ?AstClassReference
     {
         return $this->astClassReferences[$className->toString()] ?? null;

--- a/src/DependencyEmitter/UsesDependencyEmitter.php
+++ b/src/DependencyEmitter/UsesDependencyEmitter.php
@@ -23,7 +23,7 @@ class UsesDependencyEmitter implements DependencyEmitterInterface
             foreach ($fileReference->getAstClassReferences() as $astClassReference) {
                 foreach ($dependencies as $emittedDependency) {
                     if (AstDependency::USE === $emittedDependency->getType() &&
-                        !$this->isNamespace($emittedDependency, $astMap)
+                        $this->isFQDN($emittedDependency, $astMap)
                     ) {
                         $dependencyResult->addDependency(
                             new Dependency(
@@ -38,7 +38,7 @@ class UsesDependencyEmitter implements DependencyEmitterInterface
         }
     }
 
-    protected function isNamespace(AstDependency $dependency, AstMap $astMap): bool
+    protected function isFQDN(AstDependency $dependency, AstMap $astMap): bool
     {
         $dependencyFQDN = $dependency->getTokenName()->toString();
         $references = array_merge($astMap->getAstClassReferences(), $astMap->getAstFunctionReferences());
@@ -60,6 +60,6 @@ class UsesDependencyEmitter implements DependencyEmitterInterface
             }
         }
 
-        return $isNamespace && !$isFQDN;
+        return !$isNamespace || $isFQDN;
     }
 }

--- a/src/DependencyEmitter/UsesDependencyEmitter.php
+++ b/src/DependencyEmitter/UsesDependencyEmitter.php
@@ -41,12 +41,7 @@ class UsesDependencyEmitter implements DependencyEmitterInterface
     protected function isNamespace(AstDependency $dependency, AstMap $astMap): bool
     {
         $dependencyFQDN = $dependency->getTokenName()->toString();
-
-        $functionReferences = array_merge(...array_values(array_map(
-            static function ($file) { return $file->getFunctionReferences(); },
-            $astMap->getAstFileReferences()
-        )));
-        $references = array_merge($astMap->getAstClassReferences(), $functionReferences);
+        $references = array_merge($astMap->getAstClassReferences(), $astMap->getAstFunctionReferences());
 
         $isFQDN = false;
         $isNamespace = false;

--- a/src/DependencyEmitter/UsesDependencyEmitter.php
+++ b/src/DependencyEmitter/UsesDependencyEmitter.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace Qossmic\Deptrac\DependencyEmitter;
 
 use Qossmic\Deptrac\AstRunner\AstMap;
+use Qossmic\Deptrac\AstRunner\AstMap\AstDependency;
 use Qossmic\Deptrac\Dependency\Dependency;
 use Qossmic\Deptrac\Dependency\Result;
 
@@ -21,7 +22,9 @@ class UsesDependencyEmitter implements DependencyEmitterInterface
             $dependencies = $fileReference->getDependencies();
             foreach ($fileReference->getAstClassReferences() as $astClassReference) {
                 foreach ($dependencies as $emittedDependency) {
-                    if (AstMap\AstDependency::USE === $emittedDependency->getType()) {
+                    if (AstDependency::USE === $emittedDependency->getType() &&
+                        !$this->isNamespace($emittedDependency, $astMap)
+                    ) {
                         $dependencyResult->addDependency(
                             new Dependency(
                                 $astClassReference->getTokenName(),
@@ -33,5 +36,35 @@ class UsesDependencyEmitter implements DependencyEmitterInterface
                 }
             }
         }
+    }
+
+    protected function isNamespace(AstDependency $dependency, AstMap $astMap): bool
+    {
+        $dependencyFQDN = $dependency->getTokenName()->toString();
+
+        $functionReferences = array_merge(...array_values(array_map(
+            static function ($file) { return $file->getFunctionReferences(); },
+            $astMap->getAstFileReferences()
+        )));
+        $references = array_merge($astMap->getAstClassReferences(), $functionReferences);
+
+        $isFQDN = false;
+        $isNamespace = false;
+
+        foreach ($references as $reference) {
+            $referenceFQDN = $reference->getTokenName()->toString();
+
+            if ($referenceFQDN === $dependencyFQDN) {
+                $isFQDN = true;
+            }
+
+            if (0 === strpos($referenceFQDN, $dependencyFQDN, 0) &&
+                $referenceFQDN !== $dependencyFQDN
+            ) {
+                $isNamespace = true;
+            }
+        }
+
+        return $isNamespace && !$isFQDN;
     }
 }

--- a/tests/DependencyEmitter/EmitterTrait.php
+++ b/tests/DependencyEmitter/EmitterTrait.php
@@ -18,6 +18,9 @@ use Symfony\Component\EventDispatcher\EventDispatcher;
 
 trait EmitterTrait
 {
+    /**
+     * @param string|string[] $files
+     */
     public function getDeps(DependencyEmitterInterface $emitter, $files): array
     {
         $files = (array) $files;

--- a/tests/DependencyEmitter/EmitterTrait.php
+++ b/tests/DependencyEmitter/EmitterTrait.php
@@ -18,15 +18,17 @@ use Symfony\Component\EventDispatcher\EventDispatcher;
 
 trait EmitterTrait
 {
-    public function getDeps(DependencyEmitterInterface $emitter, string $file): array
+    public function getDeps(DependencyEmitterInterface $emitter, $files): array
     {
+        $files = (array) $files;
+
         $parser = new NikicPhpParser(
             ParserFactory::createParser(),
             new AstFileReferenceInMemoryCache(),
             new TypeResolver(),
             new AnonymousClassResolver()
         );
-        $astMap = (new AstRunner(new EventDispatcher(), $parser))->createAstMapByFiles([$file], ConfigurationAnalyser::fromArray(
+        $astMap = (new AstRunner(new EventDispatcher(), $parser))->createAstMapByFiles($files, ConfigurationAnalyser::fromArray(
             []));
         $result = new Result();
 

--- a/tests/DependencyEmitter/Fixtures/FQDNNamespacePrefix/FQDN.php
+++ b/tests/DependencyEmitter/Fixtures/FQDNNamespacePrefix/FQDN.php
@@ -1,0 +1,5 @@
+<?php
+
+namespace FQDNNamespacePrefix;
+
+class FQDN {}

--- a/tests/DependencyEmitter/Fixtures/FQDNNamespacePrefix/FQDN/SomeClass.php
+++ b/tests/DependencyEmitter/Fixtures/FQDNNamespacePrefix/FQDN/SomeClass.php
@@ -1,0 +1,5 @@
+<?php
+
+namespace FQDNNamespacePrefix\FQDN;
+
+class SomeClass {}

--- a/tests/DependencyEmitter/Fixtures/FQDNNamespacePrefix/Uses/Foo.php
+++ b/tests/DependencyEmitter/Fixtures/FQDNNamespacePrefix/Uses/Foo.php
@@ -1,0 +1,14 @@
+<?php
+
+namespace FQDNNamespacePrefix\Uses;
+
+use FQDNNamespacePrefix\FQDN;
+
+class Foo
+{
+    public function bar()
+    {
+        $fqdn = new FQDN();
+        $someClass = new FQDN\SomeClass();
+    }
+}

--- a/tests/DependencyEmitter/Fixtures/IgnoreNamespace/Deps/Functions.php
+++ b/tests/DependencyEmitter/Fixtures/IgnoreNamespace/Deps/Functions.php
@@ -1,0 +1,7 @@
+<?php
+
+namespace IgnoreNamespace\Deps;
+
+function functionUsedWithFQDN() {}
+
+function functionUsedWithNamespace() {}

--- a/tests/DependencyEmitter/Fixtures/IgnoreNamespace/Deps/UsedWithFQDN.php
+++ b/tests/DependencyEmitter/Fixtures/IgnoreNamespace/Deps/UsedWithFQDN.php
@@ -1,0 +1,5 @@
+<?php
+
+namespace IgnoreNamespace\Deps;
+
+class UsedWithFQDN {}

--- a/tests/DependencyEmitter/Fixtures/IgnoreNamespace/Deps/UsedWithNamespace.php
+++ b/tests/DependencyEmitter/Fixtures/IgnoreNamespace/Deps/UsedWithNamespace.php
@@ -1,0 +1,5 @@
+<?php
+
+namespace IgnoreNamespace\Deps;
+
+class UsedWithNamespace {}

--- a/tests/DependencyEmitter/Fixtures/IgnoreNamespace/Uses/Foo.php
+++ b/tests/DependencyEmitter/Fixtures/IgnoreNamespace/Uses/Foo.php
@@ -1,0 +1,18 @@
+<?php
+
+namespace IgnoreNamespace\Uses;
+
+use IgnoreNamespace\Deps;
+use IgnoreNamespace\Deps\UsedWithFQDN;
+use IgnoreNamespace\Deps\Functions\functionUsedWithFQDN;
+
+class Foo
+{
+    public function bar()
+    {
+        functionUsedWithFQDN();
+
+        $someClass = new Deps\ClassUsedWithNamespace();
+        Deps\functionUsedWithNamespace();
+    }
+}

--- a/tests/DependencyEmitter/UsesDependencyEmitterTest.php
+++ b/tests/DependencyEmitter/UsesDependencyEmitterTest.php
@@ -26,4 +26,37 @@ final class UsesDependencyEmitterTest extends TestCase
         self::assertCount(1, $deps);
         self::assertContains('Foo\Bar:4 on SomeUse', $deps);
     }
+
+    public function testIgnoresNamespaces(): void
+    {
+        $deps = $this->getDeps(
+            new UsesDependencyEmitter(),
+            [
+                __DIR__.'/Fixtures/IgnoreNamespace/Deps/UsedWithFQDN.php',
+                __DIR__.'/Fixtures/IgnoreNamespace/Deps/UsedWithNamespace.php',
+                __DIR__.'/Fixtures/IgnoreNamespace/Deps/Functions.php',
+                __DIR__.'/Fixtures/IgnoreNamespace/Uses/Foo.php',
+            ]
+        );
+
+        self::assertCount(2, $deps);
+        self::assertNotContains('IgnoreNamespace\Uses\Foo:5 on IgnoreNamespace\Deps', $deps);
+        self::assertContains('IgnoreNamespace\Uses\Foo:6 on IgnoreNamespace\Deps\UsedWithFQDN', $deps);
+        self::assertContains('IgnoreNamespace\Uses\Foo:7 on IgnoreNamespace\Deps\Functions\functionUsedWithFQDN', $deps);
+    }
+
+    public function testIncludesFQDNWhichIsAlsoANamespacePrefix(): void
+    {
+        $deps = $this->getDeps(
+            new UsesDependencyEmitter(),
+            [
+                __DIR__.'/Fixtures/FQDNNamespacePrefix/FQDN.php',
+                __DIR__.'/Fixtures/FQDNNamespacePrefix/FQDN/SomeClass.php',
+                __DIR__.'/Fixtures/FQDNNamespacePrefix/Uses/Foo.php',
+            ]
+        );
+
+        self::assertCount(1, $deps);
+        self::assertContains('FQDNNamespacePrefix\Uses\Foo:5 on FQDNNamespacePrefix\FQDN', $deps);
+    }
 }


### PR DESCRIPTION
Fixes #758.

Prevent namespaces from being added to use dependencies. Namespaces are
detected by looking if the used FQDN is a prefix of some class FQDN.

This strategy may be a bit brittle, I'll let you judge if this good enough or if the current behavior is better.