### PR TITLE
Fix debug commands when using new config-file option

### DIFF
--- a/src/Console/Command/DebugLayerCommand.php
+++ b/src/Console/Command/DebugLayerCommand.php
@@ -13,6 +13,8 @@ use Symfony\Component\Console\Input\InputInterface;
 use Symfony\Component\Console\Input\InputOption;
 use Symfony\Component\Console\Output\OutputInterface;
 use Symfony\Component\Console\Style\SymfonyStyle;
+use function getcwd;
+use const DIRECTORY_SEPARATOR;
 
 class DebugLayerCommand extends Command
 {
@@ -35,7 +37,13 @@ class DebugLayerCommand extends Command
         parent::configure();
 
         $this->addArgument('layer', InputArgument::OPTIONAL, 'Layer to debug');
-        $this->addOption('depfile', null, InputOption::VALUE_OPTIONAL, 'Path to the depfile');
+        $this->addOption(
+            'depfile',
+            null,
+            InputOption::VALUE_REQUIRED,
+            '!deprecated: use --config-file instead - Path to the depfile',
+            getcwd().DIRECTORY_SEPARATOR.'depfile.yaml'
+        );
     }
 
     protected function execute(InputInterface $input, OutputInterface $output): int
@@ -44,10 +52,9 @@ class DebugLayerCommand extends Command
         $symfonyOutput = new SymfonyOutput($output, $outputStyle);
         /** @var ?string $layer */
         $layer = $input->getArgument('layer');
-        $options = new DebugLayerOptions(
-            self::getConfigFile($input, $symfonyOutput),
-            $layer
-        );
+        $configFile = self::getConfigFile($input, $symfonyOutput);
+
+        $options = new DebugLayerOptions($configFile, $layer);
 
         try {
             $this->runner->run($options, $symfonyOutput);

--- a/src/Console/Command/DebugLayerOptions.php
+++ b/src/Console/Command/DebugLayerOptions.php
@@ -2,24 +2,14 @@
 
 namespace Qossmic\Deptrac\Console\Command;
 
-use Qossmic\Deptrac\Exception\Console\InvalidArgumentException;
-use function is_string;
-
 class DebugLayerOptions
 {
     private string $configurationFile;
 
     private ?string $layer;
 
-    /**
-     * @param mixed $configurationFile
-     */
-    public function __construct($configurationFile, ?string $layer)
+    public function __construct(string $configurationFile, ?string $layer)
     {
-        if (!is_string($configurationFile)) {
-            throw InvalidArgumentException::invalidDepfileType($configurationFile);
-        }
-
         $this->configurationFile = $configurationFile;
         $this->layer = $layer;
     }

--- a/src/Console/Command/DebugTokenCommand.php
+++ b/src/Console/Command/DebugTokenCommand.php
@@ -12,6 +12,8 @@ use Symfony\Component\Console\Input\InputInterface;
 use Symfony\Component\Console\Input\InputOption;
 use Symfony\Component\Console\Output\OutputInterface;
 use Symfony\Component\Console\Style\SymfonyStyle;
+use function getcwd;
+use const DIRECTORY_SEPARATOR;
 
 class DebugTokenCommand extends Command
 {
@@ -35,7 +37,13 @@ class DebugTokenCommand extends Command
 
         $this->addArgument('token', InputArgument::REQUIRED, 'Full qualified token name to debug');
         $this->addArgument('type', InputArgument::OPTIONAL, 'Token type (class-like, function, file)', 'class-like');
-        $this->addOption('depfile', null, InputOption::VALUE_OPTIONAL, 'Path to the depfile');
+        $this->addOption(
+            'depfile',
+            null,
+            InputOption::VALUE_REQUIRED,
+            '!deprecated: use --config-file instead - Path to the depfile',
+            getcwd().DIRECTORY_SEPARATOR.'depfile.yaml'
+        );
     }
 
     protected function execute(InputInterface $input, OutputInterface $output): int

--- a/src/Console/Command/DebugUnassignedCommand.php
+++ b/src/Console/Command/DebugUnassignedCommand.php
@@ -11,6 +11,8 @@ use Symfony\Component\Console\Input\InputArgument;
 use Symfony\Component\Console\Input\InputInterface;
 use Symfony\Component\Console\Output\OutputInterface;
 use Symfony\Component\Console\Style\SymfonyStyle;
+use function getcwd;
+use const DIRECTORY_SEPARATOR;
 
 class DebugUnassignedCommand extends Command
 {
@@ -32,7 +34,12 @@ class DebugUnassignedCommand extends Command
     {
         parent::configure();
 
-        $this->addArgument('depfile', InputArgument::REQUIRED, 'Path to the depfile');
+        $this->addArgument(
+            'depfile',
+            InputArgument::OPTIONAL,
+            '!deprecated: use --config-file instead - Path to the depfile',
+            getcwd().DIRECTORY_SEPARATOR.'depfile.yaml'
+        );
     }
 
     protected function execute(InputInterface $input, OutputInterface $output): int

--- a/src/Console/Command/DefaultDepFileTrait.php
+++ b/src/Console/Command/DefaultDepFileTrait.php
@@ -17,11 +17,18 @@ trait DefaultDepFileTrait
     {
         /** @var string $configFile */
         $configFile = $input->getOption('config-file');
-        /** @var string $legacyFile */
-        $legacyFile = $input->getArgument('depfile');
 
         $defaultConfigFile = DIRECTORY_SEPARATOR.'deptrac.yaml';
         $defaultLegacyFile = DIRECTORY_SEPARATOR.'depfile.yaml';
+
+        $legacyFile = $defaultLegacyFile;
+        if ($input->hasArgument('depfile')) {
+            /** @var string $legacyFile */
+            $legacyFile = $input->getArgument('depfile');
+        } elseif ($input->hasOption('depfile')) {
+            /** @var string $legacyFile */
+            $legacyFile = $input->getOption('depfile');
+        }
 
         if (0 !== substr_compare($configFile, $defaultConfigFile, -strlen($defaultConfigFile))
             || (file_exists($configFile)


### PR DESCRIPTION
Make depfile argument optional in all commands.

Bug was caused by the command still expecting the required, deprecated depfile argument.