### PR TITLE
Allow graphviz-image to output image in different formats.

### DIFF
--- a/docs/formatters.md
+++ b/docs/formatters.md
@@ -61,7 +61,7 @@ on what type of output you are expecting. They can be activated with:
 --formatter=graphviz-display    Automatically tries to open the image
 --formatter=graphviz-dot        Saves the output to a .dot file
 --formatter=graphviz-html       Saves the output to a .html file
---formatter=graphviz-image      Saves the output to a .png file
+--formatter=graphviz-image      Saves the output to a supported image file format such as png, svg or jpg
 ```
 
 Supported options:

--- a/src/OutputFormatter/GraphVizOutputImageFormatter.php
+++ b/src/OutputFormatter/GraphVizOutputImageFormatter.php
@@ -9,6 +9,7 @@ use phpDocumentor\GraphViz\Exception;
 use phpDocumentor\GraphViz\Graph;
 use Qossmic\Deptrac\Console\Output;
 use SplFileInfo;
+use Symfony\Component\Filesystem\Path;
 
 final class GraphVizOutputImageFormatter extends GraphVizOutputFormatter
 {
@@ -22,12 +23,12 @@ final class GraphVizOutputImageFormatter extends GraphVizOutputFormatter
         $dumpImagePath = $outputFormatterInput->getOutputPath();
         if (null !== $dumpImagePath) {
             $imageFile = new SplFileInfo($dumpImagePath);
-            if (!is_dir($imageFile->getPath()) && !mkdir($imageFile->getPath())) {
-                throw new LogicException(sprintf('Unable to dump image: Path "%s" does not exist and is not writable.', $imageFile->getPath()));
+            if (!$imageFile->getPathInfo()->isWritable()) {
+                throw new LogicException(sprintf('Unable to dump image: Path "%s" does not exist or is not writable.', Path::canonicalize($imageFile->getPathInfo()->getPathname())));
             }
             try {
-                $graph->export('png', $dumpImagePath);
-                $output->writeLineFormatted('<info>Image dumped to '.realpath($dumpImagePath).'</info>');
+                $graph->export($imageFile->getExtension() ?: 'png', $imageFile->getPathname());
+                $output->writeLineFormatted('<info>Image dumped to '.$imageFile->getPathname().'</info>');
             } catch (Exception $exception) {
                 throw new LogicException('Unable to display output: '.$exception->getMessage());
             }


### PR DESCRIPTION
Tested locally (macOS) with svg, jpg & pdf and worked fine. When picking a format that is not valid, graphviz will conveniently tell us the supported formats:

```
 [ERROR]                                                                                                                
                                                                                                                        
         Output formatter graphviz-image threw an Exception:                                                            
                                                                                                                        
         Message: Unable to display output: An error occurred while creating the graph; GraphViz returned: Format:      
         "html" not recognized. Use one of: bmp canon cgimage cmap cmapx cmapx_np dot dot_json eps exr fig gd gd2 gif gv
         icns ico imap imap_np ismap jp2 jpe jpeg jpg json json0 mp pct pdf pic pict plain plain-ext png pov ps ps2 psd 
         sgi svg svgz tga tif tiff tk vdx vml vmlz vrml wbmp webp xdot xdot1.2 xdot1.4 xdot_json                                                                                                                  
```