### PR TITLE
Allow more logic in configuration using php

### DIFF
--- a/config/services.php
+++ b/config/services.php
@@ -30,6 +30,7 @@ use Qossmic\Deptrac\Collector\UsesCollector;
 use Qossmic\Deptrac\Configuration\Dumper;
 use Qossmic\Deptrac\Configuration\Loader;
 use Qossmic\Deptrac\Configuration\Loader\YmlFileLoader;
+use Qossmic\Deptrac\Configuration\LoaderResolver;
 use Qossmic\Deptrac\Configuration\ParameterResolver;
 use Qossmic\Deptrac\Console\Command\AnalyseCommand;
 use Qossmic\Deptrac\Console\Command\AnalyseRunner;
@@ -137,6 +138,12 @@ return static function (ContainerConfigurator $container): void {
             service(AstRunner::class),
             service(FileResolver::class),
             service(TokenLayerResolverFactory::class),
+        ]);
+
+    $services
+        ->set(LoaderResolver::class)
+        ->args([
+            service(Loader::class),
         ]);
 
     $services

--- a/src/Configuration/Loader.php
+++ b/src/Configuration/Loader.php
@@ -17,7 +17,7 @@ use function dirname;
 use function sprintf;
 use function trigger_deprecation;
 
-class Loader
+class Loader implements LoaderInterface
 {
     private YmlFileLoader $fileLoader;
     private Processor $processor;

--- a/src/Configuration/LoaderInterface.php
+++ b/src/Configuration/LoaderInterface.php
@@ -1,0 +1,10 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Qossmic\Deptrac\Configuration;
+
+interface LoaderInterface
+{
+    public function load(string $file): Configuration;
+}

--- a/src/Configuration/LoaderResolver.php
+++ b/src/Configuration/LoaderResolver.php
@@ -1,0 +1,24 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Qossmic\Deptrac\Configuration;
+
+class LoaderResolver
+{
+    private Loader $ymlLoader;
+
+    public function __construct(Loader $ymlLoader)
+    {
+        $this->ymlLoader = $ymlLoader;
+    }
+
+    public function resolve(string $filename): LoaderInterface
+    {
+        if (false !== strpos($filename, '.php')) {
+            return new PhpLoader();
+        }
+
+        return $this->ymlLoader;
+    }
+}

--- a/src/Configuration/PhpLoader.php
+++ b/src/Configuration/PhpLoader.php
@@ -1,0 +1,20 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Qossmic\Deptrac\Configuration;
+
+class PhpLoader implements LoaderInterface
+{
+    /**
+     * @psalm-suppress MixedInferredReturnType
+     */
+    public function load(string $file): Configuration
+    {
+        /**
+         * @psalm-suppress MixedReturnStatement
+         * @psalm-suppress UnresolvableInclude This `require` is a runtime dependency
+         */
+        return require $file;
+    }
+}

--- a/src/Console/Command/AnalyseRunner.php
+++ b/src/Console/Command/AnalyseRunner.php
@@ -6,7 +6,7 @@ namespace Qossmic\Deptrac\Console\Command;
 
 use LogicException;
 use Qossmic\Deptrac\Analyser;
-use Qossmic\Deptrac\Configuration\Loader as ConfigurationLoader;
+use Qossmic\Deptrac\Configuration\LoaderResolver;
 use Qossmic\Deptrac\Console\Output;
 use Qossmic\Deptrac\Exception\Console\AnalyseException;
 use Qossmic\Deptrac\OutputFormatter\OutputFormatterInput;
@@ -21,12 +21,12 @@ use function sprintf;
 final class AnalyseRunner
 {
     private Analyser $analyser;
-    private ConfigurationLoader $configurationLoader;
+    private LoaderResolver $configurationLoader;
     private OutputFormatterFactory $formatterFactory;
 
     public function __construct(
         Analyser $analyser,
-        ConfigurationLoader $configurationLoader,
+        LoaderResolver $configurationLoader,
         OutputFormatterFactory $formatterFactory
     ) {
         $this->analyser = $analyser;
@@ -36,7 +36,7 @@ final class AnalyseRunner
 
     public function run(AnalyseOptions $options, Output $output): void
     {
-        $configuration = $this->configurationLoader->load($options->getConfigurationFile());
+        $configuration = $this->configurationLoader->resolve($options->getConfigurationFile())->load($options->getConfigurationFile());
 
         try {
             $formatter = $this->formatterFactory->getFormatterByName($options->getFormatter());


### PR DESCRIPTION
There wasn't that much thoughts put in this pull request, its more about the idea than it is about the implementation.

For some (pretty big) projects, I use some scripts to automate the creation of differents depfile.yaml : 
- one to ensure no code from folder src/BusinessA is called in src/BusinessB
- one to ensure no code from src/\*/Application is called from src/\*/Domain, no code from src/\*/Infrastructure is called from either src/\*/Application or src/\*/Domain
- one to ensure that code from one vendor cannot be called except from one specific place (to wrap everything) (though in fact it is merged with previous depfile)

The code from the second depfile is easy to represent statically, but the first and the last are more complex ; and that complexity can be chosen to improve our quality of life.

In the end, I feel like I'd rather turn to PHP when Yaml is not enough, and allow php devs to use php to describe their needs, instead of bash for instance.

Would that be possible ?