### PR TITLE
Add formatter configuration, so that extensions can autowire it.

### DIFF
--- a/config/services.php
+++ b/config/services.php
@@ -25,6 +25,7 @@ use Qossmic\Deptrac\Ast\Parser\ClassConstantExtractor;
 use Qossmic\Deptrac\Ast\Parser\NikicPhpParser\NikicPhpParser;
 use Qossmic\Deptrac\Ast\Parser\ParserInterface;
 use Qossmic\Deptrac\Ast\Parser\TypeResolver;
+use Qossmic\Deptrac\Configuration\FormatterConfiguration;
 use Qossmic\Deptrac\Console\Command\AnalyseCommand;
 use Qossmic\Deptrac\Console\Command\AnalyseRunner;
 use Qossmic\Deptrac\Console\Command\DebugLayerCommand;
@@ -274,6 +275,11 @@ return static function (ContainerConfigurator $container): void {
      * OutputFormatter
      */
     $services
+        ->set(FormatterConfiguration::class)
+        ->args([
+            '$config' => param('formatters'),
+        ]);
+    $services
         ->set(FormatterProvider::class)
         ->args([
             '$formatterLocator' => tagged_locator('output_formatter', null, 'getName'),
@@ -301,33 +307,18 @@ return static function (ContainerConfigurator $container): void {
         ->tag('output_formatter');
     $services
         ->set(GraphVizOutputDisplayFormatter::class)
-        ->args([
-            '$config' => param('formatters'),
-        ])
         ->tag('output_formatter');
     $services
         ->set(GraphVizOutputImageFormatter::class)
-        ->args([
-            '$config' => param('formatters'),
-        ])
         ->tag('output_formatter');
     $services
         ->set(GraphVizOutputDotFormatter::class)
-        ->args([
-            '$config' => param('formatters'),
-        ])
         ->tag('output_formatter');
     $services
         ->set(GraphVizOutputHtmlFormatter::class)
-        ->args([
-            '$config' => param('formatters'),
-        ])
         ->tag('output_formatter');
     $services
         ->set(CodeclimateOutputFormatter::class)
-        ->args([
-            '$config' => param('formatters'),
-        ])
         ->tag('output_formatter');
 
     /*

--- a/src/Configuration/FormatterConfiguration.php
+++ b/src/Configuration/FormatterConfiguration.php
@@ -20,8 +20,8 @@ class FormatterConfiguration
     /**
      * @return array<mixed>
      */
-    public function getConfigFor(?string $area): array
+    public function getConfigFor(string $area): array
     {
-        return null === $area ? $this->config : ($this->config[$area] ?? []);
+        return $this->config[$area] ?? [];
     }
 }

--- a/src/Configuration/FormatterConfiguration.php
+++ b/src/Configuration/FormatterConfiguration.php
@@ -1,0 +1,27 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Qossmic\Deptrac\Configuration;
+
+class FormatterConfiguration
+{
+    /** @var array<string, array<mixed>> */
+    private $config;
+
+    /**
+     * @param array<string, array<mixed>> $config
+     */
+    public function __construct(array $config)
+    {
+        $this->config = $config;
+    }
+
+    /**
+     * @return array<mixed>
+     */
+    public function getConfigFor(?string $area): array
+    {
+        return null === $area ? $this->config : ($this->config[$area] ?? []);
+    }
+}

--- a/src/OutputFormatter/CodeclimateOutputFormatter.php
+++ b/src/OutputFormatter/CodeclimateOutputFormatter.php
@@ -6,6 +6,7 @@ namespace Qossmic\Deptrac\OutputFormatter;
 
 use Exception;
 use Qossmic\Deptrac\Configuration\ConfigurationCodeclimate;
+use Qossmic\Deptrac\Configuration\FormatterConfiguration;
 use Qossmic\Deptrac\Configuration\OutputFormatterInput;
 use Qossmic\Deptrac\Console\Output;
 use Qossmic\Deptrac\Result\LegacyResult;
@@ -25,12 +26,11 @@ final class CodeclimateOutputFormatter implements OutputFormatterInterface
      */
     private array $config;
 
-    /**
-     * @param array{codeclimate?: array{severity?: array{failure?: string, skipped?: string, uncovered?: string}}} $config
-     */
-    public function __construct(array $config)
+    public function __construct(FormatterConfiguration $config)
     {
-        $this->config = $config['codeclimate'] ?? [];
+        /** @var array{severity?: array{failure?: string, skipped?: string, uncovered?: string}} $extractedConfig */
+        $extractedConfig = $config->getConfigFor('codeclimate');
+        $this->config = $extractedConfig;
     }
 
     public static function getName(): string

--- a/src/OutputFormatter/GraphVizOutputFormatter.php
+++ b/src/OutputFormatter/GraphVizOutputFormatter.php
@@ -9,6 +9,7 @@ use phpDocumentor\GraphViz\Exception;
 use phpDocumentor\GraphViz\Graph;
 use phpDocumentor\GraphViz\Node;
 use Qossmic\Deptrac\Configuration\ConfigurationGraphViz;
+use Qossmic\Deptrac\Configuration\FormatterConfiguration;
 use Qossmic\Deptrac\Configuration\OutputFormatterInput;
 use Qossmic\Deptrac\Console\Output;
 use Qossmic\Deptrac\Result\CoveredRule;
@@ -27,12 +28,11 @@ abstract class GraphVizOutputFormatter implements OutputFormatterInterface
      */
     private array $config;
 
-    /**
-     * @param array{graphviz?: array{hidden_layers?: string[], groups?: array<string, string[]>, pointToGroups?: bool}} $config
-     */
-    public function __construct(array $config)
+    public function __construct(FormatterConfiguration $config)
     {
-        $this->config = $config['graphviz'] ?? [];
+        /** @var array{hidden_layers?: string[], groups?: array<string, string[]>, pointToGroups?: bool}  $extractedConfig */
+        $extractedConfig = $config->getConfigFor('graphviz');
+        $this->config = $extractedConfig;
     }
 
     public function finish(

--- a/tests/OutputFormatter/CodeclimateOutputFormatterTest.php
+++ b/tests/OutputFormatter/CodeclimateOutputFormatterTest.php
@@ -9,6 +9,7 @@ use PHPUnit\Framework\TestCase;
 use Qossmic\Deptrac\Ast\AstMap\AstInherit;
 use Qossmic\Deptrac\Ast\AstMap\ClassLike\ClassLikeToken;
 use Qossmic\Deptrac\Ast\AstMap\FileOccurrence;
+use Qossmic\Deptrac\Configuration\FormatterConfiguration;
 use Qossmic\Deptrac\Configuration\OutputFormatterInput;
 use Qossmic\Deptrac\Console\Symfony\Style;
 use Qossmic\Deptrac\Console\Symfony\SymfonyOutput;
@@ -375,9 +376,9 @@ final class CodeclimateOutputFormatterTest extends TestCase
     ): void {
         $bufferedOutput = new BufferedOutput();
 
-        $formatter = new CodeclimateOutputFormatter([
+        $formatter = new CodeclimateOutputFormatter(new FormatterConfiguration([
             'codeclimate' => $inputConfig,
-        ]);
+        ]));
         $formatter->finish(
             new LegacyResult($rules, [], []),
             $this->createSymfonyOutput($bufferedOutput),
@@ -407,9 +408,9 @@ final class CodeclimateOutputFormatterTest extends TestCase
     ): void {
         $bufferedOutput = new BufferedOutput();
 
-        $formatter = new CodeclimateOutputFormatter([
+        $formatter = new CodeclimateOutputFormatter(new FormatterConfiguration([
             'codeclimate' => $inputConfig,
-        ]);
+        ]));
         $formatter->finish(
             new LegacyResult($rules, [], []),
             $this->createSymfonyOutput($bufferedOutput),
@@ -430,7 +431,7 @@ final class CodeclimateOutputFormatterTest extends TestCase
     public function testJsonRenderError(): void
     {
         $bufferedOutput = new BufferedOutput();
-        $formatter = new CodeclimateOutputFormatter([]);
+        $formatter = new CodeclimateOutputFormatter(new FormatterConfiguration([]));
 
         $malformedCharacters = "\xB1\x31";
         $violation = new Violation(

--- a/tests/OutputFormatter/GraphVizDotOutputFormatterTest.php
+++ b/tests/OutputFormatter/GraphVizDotOutputFormatterTest.php
@@ -7,6 +7,7 @@ namespace Tests\Qossmic\Deptrac\OutputFormatter;
 use PHPUnit\Framework\TestCase;
 use Qossmic\Deptrac\Ast\AstMap\ClassLike\ClassLikeToken;
 use Qossmic\Deptrac\Ast\AstMap\FileOccurrence;
+use Qossmic\Deptrac\Configuration\FormatterConfiguration;
 use Qossmic\Deptrac\Configuration\OutputFormatterInput;
 use Qossmic\Deptrac\Console\Symfony\Style;
 use Qossmic\Deptrac\Console\Symfony\SymfonyOutput;
@@ -45,13 +46,13 @@ final class GraphVizDotOutputFormatterTest extends TestCase
             false,
         );
 
-        (new GraphVizOutputDotFormatter([
+        (new GraphVizOutputDotFormatter(new FormatterConfiguration([
             'graphviz' => [
                 'hidden_layers' => [
                     'LayerHidden',
                 ],
             ],
-        ]))->finish($context, $this->createSymfonyOutput($bufferedOutput), $input);
+        ])))->finish($context, $this->createSymfonyOutput($bufferedOutput), $input);
 
         self::assertSame(sprintf("Script dumped to %s\n", $dotFile), $bufferedOutput->fetch());
         self::assertFileEquals(__DIR__.'/data/graphviz-expected.dot', $dotFile);
@@ -84,7 +85,7 @@ final class GraphVizDotOutputFormatterTest extends TestCase
             false,
         );
 
-        (new GraphVizOutputDotFormatter([
+        (new GraphVizOutputDotFormatter(new FormatterConfiguration([
             'graphviz' => [
                 'groups' => [
                     'User' => [
@@ -97,7 +98,7 @@ final class GraphVizDotOutputFormatterTest extends TestCase
                     ],
                 ],
             ],
-        ]))->finish($context, $this->createSymfonyOutput($bufferedOutput), $input);
+        ])))->finish($context, $this->createSymfonyOutput($bufferedOutput), $input);
 
         self::assertSame(sprintf("Script dumped to %s\n", $dotFile), $bufferedOutput->fetch());
         self::assertFileEquals(__DIR__.'/data/graphviz-groups.dot', $dotFile);
@@ -130,7 +131,7 @@ final class GraphVizDotOutputFormatterTest extends TestCase
             false,
         );
 
-        (new GraphVizOutputDotFormatter([
+        (new GraphVizOutputDotFormatter(new FormatterConfiguration([
             'graphviz' => [
                 'groups' => [
                     'User' => [
@@ -144,7 +145,7 @@ final class GraphVizDotOutputFormatterTest extends TestCase
                 ],
                 'pointToGroups' => true,
             ],
-        ]))->finish($context, $this->createSymfonyOutput($bufferedOutput), $input);
+        ])))->finish($context, $this->createSymfonyOutput($bufferedOutput), $input);
 
         self::assertSame(sprintf("Script dumped to %s\n", $dotFile), $bufferedOutput->fetch());
         self::assertFileEquals(__DIR__.'/data/graphviz-groups-point.dot', $dotFile);


### PR DESCRIPTION
Add a Class for formatter configuration, so that extension formatters can autowire it. Symfony is not friendly to autowiring non-class variables.