### PR TITLE
Make allowed layer resolution public

### DIFF
--- a/config/services.php
+++ b/config/services.php
@@ -68,6 +68,7 @@ use Qossmic\Deptrac\Layer\Collector\MethodCollector;
 use Qossmic\Deptrac\Layer\Collector\SuperglobalCollector;
 use Qossmic\Deptrac\Layer\Collector\TraitCollector;
 use Qossmic\Deptrac\Layer\Collector\UsesCollector;
+use Qossmic\Deptrac\Layer\LayerProvider;
 use Qossmic\Deptrac\Layer\LayerResolver;
 use Qossmic\Deptrac\Layer\LayerResolverInterface;
 use Qossmic\Deptrac\OutputFormatter\BaselineOutputFormatter;
@@ -261,10 +262,12 @@ return static function (ContainerConfigurator $container): void {
         ->set(MatchingLayersHandler::class)
         ->tag('event_listener', ['priority' => 16]);
     $services
-        ->set(AllowDependencyHandler::class)
+        ->set(LayerProvider::class)
         ->args([
             '$allowedLayers' => param('ruleset'),
-        ])
+        ]);
+    $services
+        ->set(AllowDependencyHandler::class)
         ->tag('event_listener', ['priority' => 4]);
     $services
         ->set(ViolationHandler::class)

--- a/src/Analyser/EventHandler/AllowDependencyHandler.php
+++ b/src/Analyser/EventHandler/AllowDependencyHandler.php
@@ -6,28 +6,18 @@ namespace Qossmic\Deptrac\Analyser\EventHandler;
 
 use Qossmic\Deptrac\Analyser\Event\ProcessEvent;
 use Qossmic\Deptrac\Layer\Exception\CircularReferenceException;
+use Qossmic\Deptrac\Layer\LayerProvider;
 use Qossmic\Deptrac\Result\Allowed;
 use Qossmic\Deptrac\Result\Error;
-use function array_merge;
-use function array_unique;
-use function array_values;
 use function in_array;
-use function ltrim;
-use function strncmp;
 
 class AllowDependencyHandler
 {
-    /**
-     * @var array<string, string[]>
-     */
-    private array $allowedLayers;
+    private LayerProvider $layerProvider;
 
-    /**
-     * @param array<string, string[]> $allowedLayers
-     */
-    public function __construct(array $allowedLayers)
+    public function __construct(LayerProvider $layerProvider)
     {
-        $this->allowedLayers = $allowedLayers;
+        $this->layerProvider = $layerProvider;
     }
 
     public function __invoke(ProcessEvent $event): void
@@ -38,7 +28,7 @@ class AllowDependencyHandler
 
         foreach ($event->getDependentLayers() as $dependentLayer) {
             try {
-                $allowedLayers = $this->getAllowedLayers($dependerLayer);
+                $allowedLayers = $this->layerProvider->getAllowedLayers($dependerLayer);
             } catch (CircularReferenceException $circularReferenceException) {
                 $ruleset->addError(new Error($circularReferenceException->getMessage()));
                 $event->stopPropagation();
@@ -54,35 +44,5 @@ class AllowDependencyHandler
 
             $event->stopPropagation();
         }
-    }
-
-    /**
-     * @return string[]
-     */
-    private function getAllowedLayers(string $layerName): array
-    {
-        return array_values(array_unique($this->getTransitiveDependencies($layerName, [])));
-    }
-
-    /**
-     * @param string[] $previousLayers
-     *
-     * @return string[]
-     */
-    private function getTransitiveDependencies(string $layerName, array $previousLayers): array
-    {
-        if (in_array($layerName, $previousLayers, true)) {
-            throw CircularReferenceException::circularLayerDependency($layerName, $previousLayers);
-        }
-        $dependencies = [];
-        foreach ($this->allowedLayers[$layerName] ?? [] as $layer) {
-            if (0 === strncmp($layer, '+', 1)) {
-                $layer = ltrim($layer, '+');
-                $dependencies[] = $this->getTransitiveDependencies($layer, array_merge([$layerName], $previousLayers));
-            }
-            $dependencies[] = [$layer];
-        }
-
-        return [] === $dependencies ? [] : array_merge(...$dependencies);
     }
 }

--- a/src/Layer/LayerProvider.php
+++ b/src/Layer/LayerProvider.php
@@ -1,0 +1,57 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Qossmic\Deptrac\Layer;
+
+use Qossmic\Deptrac\Layer\Exception\CircularReferenceException;
+
+class LayerProvider
+{
+    /**
+     * @var array<string, string[]>
+     */
+    private array $allowedLayers;
+
+    /**
+     * @param array<string, string[]> $allowedLayers
+     */
+    public function __construct(array $allowedLayers)
+    {
+        $this->allowedLayers = $allowedLayers;
+    }
+
+    /**
+     * @return string[]
+     *
+     * @throws CircularReferenceException
+     */
+    public function getAllowedLayers(string $layerName): array
+    {
+        return array_values(array_unique($this->getTransitiveDependencies($layerName, [])));
+    }
+
+    /**
+     * @param string[] $previousLayers
+     *
+     * @return string[]
+     *
+     * @throws CircularReferenceException
+     */
+    private function getTransitiveDependencies(string $layerName, array $previousLayers): array
+    {
+        if (in_array($layerName, $previousLayers, true)) {
+            throw CircularReferenceException::circularLayerDependency($layerName, $previousLayers);
+        }
+        $dependencies = [];
+        foreach ($this->allowedLayers[$layerName] ?? [] as $layer) {
+            if (0 === strncmp($layer, '+', 1)) {
+                $layer = ltrim($layer, '+');
+                $dependencies[] = $this->getTransitiveDependencies($layer, array_merge([$layerName], $previousLayers));
+            }
+            $dependencies[] = [$layer];
+        }
+
+        return [] === $dependencies ? [] : array_merge(...$dependencies);
+    }
+}


### PR DESCRIPTION
Making `AllowDependencyHandler::getAllowedLayers` public and static. This helper method is useful for integrations.