### PR TITLE
Automatically release deptrac via GitHub action

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,26 @@
+on:
+  workflow_dispatch:
+    inputs
+      version:
+        description: 'Please pick a release version in the format x.y.z, e.g. 0.22.1'
+        required: true
+
+jobs:
+  prepare:
+    runs-on: ubuntu-latest
+    steps:
+      - name: "📥 Check-out"
+        uses: actions/checkout@v1
+      - name: "✏️ Generate full changelog"
+        uses: heinrichreimer/github-changelog-generator-action@v2.3
+        with:
+          token: ${{ secrets.GITHUB_TOKEN }}
+          futureRelease: ${{ github.event.inputs.version }}
+          issues: false
+          output: CHANGELOG.md
+      - name: "📥 Commit changelog"
+        uses: EndBug/add-and-commit@v9
+        with:
+          add: CHANGELOG.md
+          message: "Prepare release ${{ github.event.inputs.version }}"
+          push: true


### PR DESCRIPTION
To Do:
- [ ] Tag release with version
- [ ] Add new release
    - [ ] Build deptrac and add binary as release artifact
    - [ ] Create short changelog as description for release
- [ ] Trigger release in qossmic/deptrac-shim