### PR TITLE
Fix tag for event_listener.

### DIFF
--- a/deptrac.yaml
+++ b/deptrac.yaml
@@ -4,10 +4,10 @@ imports:
 services:
   - class: Internal\Qossmic\Deptrac\IgnoreDependenciesOnContract
     tags:
-     - { name: event_listener, event: Qossmic\Deptrac\Contract\Analyser\ProcessEvent }
+     - { name: kernel.event_listener, event: Qossmic\Deptrac\Contract\Analyser\ProcessEvent }
   - class: Internal\Qossmic\Deptrac\IgnoreDependenciesOnShouldNotHappenException
     tags:
-      - { name: event_listener, event: Qossmic\Deptrac\Contract\Analyser\ProcessEvent }
+      - { name: kernel.event_listener, event: Qossmic\Deptrac\Contract\Analyser\ProcessEvent }
 
 deptrac:
   paths:


### PR DESCRIPTION
After our last dependency upgrade we reuse the original event names from Symfony with the "kernel."-prefix. Without the proper tag these listeners will not be registered automatically.