### PR TITLE
Sync docs with actual file behaviour

### DIFF
--- a/docs/collectors.md
+++ b/docs/collectors.md
@@ -23,7 +23,7 @@ parameters:
 The `bool` collector allows combining other collectors with or without negation.
 
 ```yml
-deptrac:
+parameters:
   layers:
     - name: Asset
       collectors:
@@ -48,7 +48,7 @@ qualified name to a simplified regular expression. Any match will be
 added to the assigned layer.
 
 ```yaml
-deptrac:
+parameters:
   layers:
     - name: Provider
       collectors:
@@ -67,7 +67,7 @@ qualified name to a simplified regular expression. Any match will be
 added to the assigned layer.
 
 ```yaml
-deptrac:
+parameters:
   layers:
     - name: Domain
       collectors:
@@ -86,7 +86,7 @@ qualified name to a regular expression. Any matching class will be added to the
 assigned layer.
 
 ```yaml
-deptrac:
+parameters:
   layers:
     - name: Controller
       collectors:
@@ -104,7 +104,7 @@ they are declared in to a simplified regular expression. Any matching class will
 be added to the assigned layer.
 
 ```yaml
-deptrac:
+parameters:
   layers:
     - name: Controller
       collectors:
@@ -122,7 +122,7 @@ The `extends` collector allows collecting classes extending a specified class by
 matching recursively for a fully qualified class or interface name.
 
 ```yaml
-deptrac:
+parameters:
   layers:
     - name: Foo
       collectors:
@@ -137,7 +137,7 @@ qualified name to a simplified regular expression. Any matching function will be
 added to the assigned layer.
 
 ```yaml
-deptrac:
+parameters:
   layers:
     - name: Foo
       collectors:
@@ -150,7 +150,7 @@ deptrac:
 The `glob` collector finds all files matching the provided glob pattern.
 
 ```yaml
-deptrac:
+parameters:
   layers:
     - name: Repositories
       collectors:
@@ -164,7 +164,7 @@ The `implements` collector allows collecting classes implementing a specified
 interface by matching recursively for a fully qualified interface name.
 
 ```yaml
-deptrac:
+parameters:
   layers:
     - name: Foo
       collectors:
@@ -178,7 +178,7 @@ qualified name to a simplified regular expression. Any matching interface will b
 added to the assigned layer.
 
 ```yaml
-deptrac:
+parameters:
   layers:
     - name: Contracts
       collectors:
@@ -197,7 +197,7 @@ class, whether by implementing an interface, extending another class or by using
 a trait, by matching recursively for a fully qualified class name.
 
 ```yaml
-deptrac:
+parameters:
   layers:
     - name: Foo
       collectors:
@@ -213,7 +213,7 @@ it is very useful to exclude classes in combination with
 the [`bool` Collector](#bool-collector):
 
 ```yml
-deptrac:
+parameters:
   layers:
     - name: SubDomain
       collectors:
@@ -236,7 +236,7 @@ The `method` collector allows collecting classes by matching their methods name
 to a regular expression. Any matching class will be added to the assigned layer.
 
 ```yaml
-deptrac:
+parameters:
   layers:
     - name: Foo services
       collectors:
@@ -253,7 +253,7 @@ The `superglobal` collector allows collecting superglobal PHP variables matching
 the specified superglobal name.
 
 ```yaml
-deptrac:
+parameters:
   layers:
     - name: Foo
       collectors:
@@ -270,7 +270,7 @@ qualified name to a simplified regular expression. Any matching trait will be
 added to the assigned layer.
 
 ```yaml
-deptrac:
+parameters:
   layers:
     - name: Traits
       collectors:
@@ -288,7 +288,7 @@ The `uses` collector allows collecting classes using a specified trait by
 matching recursively for a fully qualified trait name.
 
 ```yaml
-deptrac:
+parameters:
   layers:
     - name: Foo
       collectors:
@@ -311,7 +311,7 @@ If you would like to make your collector available to others, feel free to
 Any collector can also specify parameter `private:true` like this:
 
 ```yaml
-deptrac:
+parameters:
   layers:
     - name: Foo
       collectors:

--- a/docs/concepts.md
+++ b/docs/concepts.md
@@ -44,7 +44,7 @@ If your application has *controllers* and *models*, Deptrac allows you to group
 them into layers.
 
 ```yaml
-deptrac:
+parameters:
   paths:
     - ./examples/ModelController
   exclude_files: ~
@@ -132,7 +132,7 @@ As a lot of architectures define some kind of *controllers*, *services* and
 We can define this using the following depfile:
 
 ```yaml
-deptrac:
+parameters:
   paths:
     - ./examples/ControllerServiceRepository1/
   exclude_files: ~
@@ -296,7 +296,7 @@ Violations can be skipped by provided list of dependencies in *skip_violations*
 configuration section:
 
 ```yaml
-deptrac:
+parameters:
   skip_violations:
     Library\LibClass:
       - Core\CoreClass

--- a/docs/depfile.md
+++ b/docs/depfile.md
@@ -25,7 +25,7 @@ imports:
 Deptrac can have different parts of the php file as a source for the dependency. By default, only class definitions and use statements can be the source of the dependency and superglobal variable usage is not tracked. To analyse file more fully, you can define what types of `DependencyEmmiters` you want to apply on the analysed file:
 
 ```yaml
-deptrac:
+parameters:
   analyser:
     types:
       - use
@@ -52,7 +52,7 @@ defined here, than it will not be collected and added to your layers.
 Example:
 
 ```yaml
-deptrac:
+parameters:
   exclude_files:
     - '#.*Test\.php$#'
 ```
@@ -74,7 +74,7 @@ You can group multiple layers.
 Example:
 
 ```yaml
-deptrac:
+parameters:
   layers:
     - User Frontend
     - User Backend
@@ -104,7 +104,7 @@ the generated image.
 Example:
 
 ```yaml
-deptrac:
+parameters:
   formatters:
     graphviz:
       hidden_layers:
@@ -120,7 +120,7 @@ You can configure the codeclimate output by changing how severity is chosen.
 You can change how a severity of `failure`, `skipped`, `uncovered` violations will be treated.
 
 ```yaml
-deptrac:
+parameters:
   formatters:
     codeclimate:
       severity:
@@ -138,7 +138,7 @@ option to false.
 Example:
 
 ```yaml
-deptrac:
+parameters:
   ignore_uncovered_internal_classes: false
 ```
 
@@ -181,7 +181,7 @@ as well.
 Example:
 
 ```yaml
-deptrac:
+parameters:
   paths:
     - src/
     - vendor/
@@ -210,7 +210,7 @@ all layers it allows. In the example below, the Controller can now use classes
 from the Service and the Repository layer, not just the Service layer.
 
 ```yaml
-deptrac:
+parameters:
   ruleset:
     Controller:
       - +Service
@@ -228,7 +228,7 @@ listed violations are encountered. For more on this see
 Example:
 
 ```yaml
-deptrac:
+parameters:
   skip_violations:
     Library\LibClass:
       - Core\CoreClass
@@ -251,8 +251,6 @@ Example:
 ```yaml
 parameters:
   Project: MyProject
-
-deptrac:
   layers:
     -
       name: Foo

--- a/docs/examples/ControllerServiceRepository1.depfile.yaml
+++ b/docs/examples/ControllerServiceRepository1.depfile.yaml
@@ -1,4 +1,4 @@
-deptrac:
+parameters:
   paths: ["./ControllerServiceRepository1/"]
   exclude_files: []
   layers:

--- a/docs/examples/DirectoryLayer.depfile.yaml
+++ b/docs/examples/DirectoryLayer.depfile.yaml
@@ -1,4 +1,4 @@
-deptrac:
+parameters:
   paths: ["./Layer1/", "./Layer2/"]
   exclude_files: []
   layers:

--- a/docs/examples/Fixture.depfile.yaml
+++ b/docs/examples/Fixture.depfile.yaml
@@ -1,4 +1,4 @@
-deptrac:
+parameters:
   paths: ["../../tests/Core/Dependency/Emitter/Fixtures/"]
   exclude_files: []
   layers:

--- a/docs/examples/GlobCollector.depfile.yaml
+++ b/docs/examples/GlobCollector.depfile.yaml
@@ -1,4 +1,4 @@
-deptrac:
+parameters:
   paths: ["./Layer1/", "./Layer2/"]
   exclude_files: []
   layers:

--- a/docs/examples/MethodNames1.depfile.yaml
+++ b/docs/examples/MethodNames1.depfile.yaml
@@ -1,4 +1,4 @@
-deptrac:
+parameters:
   paths: ["./MethodNames1/"]
   exclude_files: []
   layers:

--- a/docs/examples/ModelController1.depfile.yaml
+++ b/docs/examples/ModelController1.depfile.yaml
@@ -1,4 +1,4 @@
-deptrac:
+parameters:
   paths: ["./ModelController1"]
   exclude_files: []
   layers:

--- a/docs/examples/ModelController2.depfile.yaml
+++ b/docs/examples/ModelController2.depfile.yaml
@@ -1,4 +1,4 @@
-deptrac:
+parameters:
   paths: ["./ModelController2"]
   exclude_files: []
   layers:

--- a/docs/examples/Parameters.depfile.yaml
+++ b/docs/examples/Parameters.depfile.yaml
@@ -1,8 +1,6 @@
 parameters:
   layer1: Layer1
   layer2: Layer2
-
-deptrac:
   paths: ["./Layer1/", "./Layer2/"]
   exclude_files: []
   layers:

--- a/docs/examples/SkipViolations.yaml
+++ b/docs/examples/SkipViolations.yaml
@@ -1,4 +1,4 @@
-deptrac:
+parameters:
   paths: ["./SkipViolations/"]
   layers:
   - name: Core

--- a/docs/examples/Transitive.depfile.yaml
+++ b/docs/examples/Transitive.depfile.yaml
@@ -1,4 +1,4 @@
-deptrac:
+parameters:
   paths: ["./Transitive"]
   exclude_files: []
   layers:

--- a/docs/examples/Uncovered.depfile.yaml
+++ b/docs/examples/Uncovered.depfile.yaml
@@ -1,4 +1,4 @@
-deptrac:
+parameters:
   paths: ["./Uncovered/"]
   layers:
     - name: Core

--- a/docs/examples/implements.depfile.yaml
+++ b/docs/examples/implements.depfile.yaml
@@ -1,4 +1,4 @@
-deptrac:
+parameters:
   paths: ["./Implements/"]
   exclude_files: []
   layers:

--- a/docs/examples/import.deptrac.yaml
+++ b/docs/examples/import.deptrac.yaml
@@ -3,7 +3,7 @@ imports:
   - 'import_layer2.deptrac.yaml'
   - 'import_baseline.deptrac.yaml'
 
-deptrac:
+parameters:
   layers:
     - name: Controller
       collectors:

--- a/docs/examples/import_baseline.deptrac.yaml
+++ b/docs/examples/import_baseline.deptrac.yaml
@@ -1,4 +1,4 @@
-deptrac:
+parameters:
   skip_violations:
     examples\Layer2\SomeOtherClass:
       - examples\Layer1\SomeClass

--- a/docs/examples/import_layer1.deptrac.yaml
+++ b/docs/examples/import_layer1.deptrac.yaml
@@ -1,4 +1,4 @@
-deptrac:
+parameters:
   paths:
     - ./Layer1
   layers:

--- a/docs/examples/import_layer2.deptrac.yaml
+++ b/docs/examples/import_layer2.deptrac.yaml
@@ -1,4 +1,4 @@
-deptrac:
+parameters:
   paths:
     - ./Layer2
   layers:

--- a/docs/examples/sylius_depfile.yaml
+++ b/docs/examples/sylius_depfile.yaml
@@ -1,4 +1,4 @@
-deptrac:
+parameters:
   paths:
     - /tmp/c1023228a
   exclude_files:

--- a/docs/examples/symfony_depfile.yaml
+++ b/docs/examples/symfony_depfile.yaml
@@ -1,4 +1,4 @@
-deptrac:
+parameters:
   paths:
       - /tmp/symfony
 

--- a/docs/formatters.md
+++ b/docs/formatters.md
@@ -86,7 +86,7 @@ There are 2 main use-cases for this feature:
   will then generate graphs focusing on only the relevant layers.
 
 ```yaml
-deptrac:
+parameters:
   layers:
     -
       name: Utils
@@ -117,7 +117,7 @@ layers into groups that will be rendered as sub-graphs in GraphViz output.
 The following config:
 
 ```yaml
-deptrac:
+parameters:
   layers:
     - User Frontend
     - User Backend
@@ -287,7 +287,7 @@ Supported options:
 Under `formatters.codeclimate.severity` you can define which severity string you want to assign to a given violation type. By default, deptrac uses `major` for failures, `minor` for skipped violations and `info` for uncovered dependencies.
 
 ```yaml
-deptrac:
+parameters:
   formatters:
     codeclimate:
       severity:

--- a/docs/index.md
+++ b/docs/index.md
@@ -125,7 +125,7 @@ Let's have a look at the generated file:
 
 ```yaml
 # deptrac.yaml
-deptrac:
+parameters:
   paths:
     - ./src
   exclude_files:

--- a/docs/upgrade.md
+++ b/docs/upgrade.md
@@ -1,3 +1,7 @@
+# Upgrade 0.24
+
+Revert the deptrac: yaml prefix and use 'parameters:' instead
+
 # Upgrade from 0.20 to 0.21
 
 # Depfile (Configuration File)


### PR DESCRIPTION
The system expects the config yaml file to start with 'parameters:' not 'deptrac:' this updates the docs to match 