### PR TITLE
Check if the file exists prior to checking if its writable

### DIFF
--- a/src/Supportive/File/Dumper.php
+++ b/src/Supportive/File/Dumper.php
@@ -30,7 +30,7 @@ class Dumper
         if ($filesystem->exists($target->getPathname())) {
             throw FileAlreadyExistsException::alreadyExists($target);
         }
-        if (!$target->isWritable()) {
+        if ($target->isFile() && !$target->isWritable()) {
             throw FileNotWritableException::notWritable($target);
         }
 


### PR DESCRIPTION
When calling `deptrac init` if the file doesn't exist then isWritable is false and we error out. 
The SplFileInfo->isFile() "Checks if the file referenced by this SplFileInfo object exists and is a regular file." 
So if it exists and is a file but is not writeable then throw an error otherwise allow the file to be created and populated.

It would likely also be smart to add more error checking here. Such as checking if the dirname($target) exists and is writeable and if not try to create it or something.