### PR TITLE
Add DependencyType.php information into the contract

### DIFF
--- a/src/Contract/Ast/DependencyType.php
+++ b/src/Contract/Ast/DependencyType.php
@@ -2,11 +2,12 @@
 
 declare(strict_types=1);
 
-namespace Qossmic\Deptrac\Core\Ast\AstMap;
+namespace Qossmic\Deptrac\Contract\Ast;
 
-enum DependencyTokenType: string
+enum DependencyType: string
 {
     case USE = 'use';
+    case INHERIT = 'inherit';
     case RETURN_TYPE = 'returntype';
     case PARAMETER = 'parameter';
     case NEW = 'new';

--- a/src/Contract/Dependency/DependencyInterface.php
+++ b/src/Contract/Dependency/DependencyInterface.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace Qossmic\Deptrac\Contract\Dependency;
 
+use Qossmic\Deptrac\Contract\Ast\DependencyType;
 use Qossmic\Deptrac\Contract\Ast\FileOccurrence;
 use Qossmic\Deptrac\Contract\Ast\TokenInterface;
 
@@ -19,4 +20,6 @@ interface DependencyInterface
      * @return array<array{name:string, line:int}>
      */
     public function serialize(): array;
+
+    public function getType(): DependencyType;
 }

--- a/src/Core/Ast/AstMap/DependencyToken.php
+++ b/src/Core/Ast/AstMap/DependencyToken.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace Qossmic\Deptrac\Core\Ast\AstMap;
 
+use Qossmic\Deptrac\Contract\Ast\DependencyType;
 use Qossmic\Deptrac\Contract\Ast\FileOccurrence;
 use Qossmic\Deptrac\Contract\Ast\TokenInterface;
 
@@ -15,7 +16,7 @@ class DependencyToken
     public function __construct(
         public readonly TokenInterface $token,
         public readonly FileOccurrence $fileOccurrence,
-        public readonly DependencyTokenType $type
+        public readonly DependencyType $type
     ) {
     }
 }

--- a/src/Core/Ast/AstMap/File/FileReferenceBuilder.php
+++ b/src/Core/Ast/AstMap/File/FileReferenceBuilder.php
@@ -4,11 +4,11 @@ declare(strict_types=1);
 
 namespace Qossmic\Deptrac\Core\Ast\AstMap\File;
 
+use Qossmic\Deptrac\Contract\Ast\DependencyType;
 use Qossmic\Deptrac\Contract\Ast\FileOccurrence;
 use Qossmic\Deptrac\Core\Ast\AstMap\ClassLike\ClassLikeReferenceBuilder;
 use Qossmic\Deptrac\Core\Ast\AstMap\ClassLike\ClassLikeToken;
 use Qossmic\Deptrac\Core\Ast\AstMap\DependencyToken;
-use Qossmic\Deptrac\Core\Ast\AstMap\DependencyTokenType;
 use Qossmic\Deptrac\Core\Ast\AstMap\FunctionLike\FunctionLikeReferenceBuilder;
 use Qossmic\Deptrac\Core\Ast\AstMap\ReferenceBuilder;
 
@@ -30,7 +30,7 @@ final class FileReferenceBuilder extends ReferenceBuilder
         $this->dependencies[] = new DependencyToken(
             ClassLikeToken::fromFQCN($classLikeName),
             new FileOccurrence($this->filepath, $occursAtLine),
-            DependencyTokenType::USE
+            DependencyType::USE
         );
 
         return $this;

--- a/src/Core/Ast/AstMap/ReferenceBuilder.php
+++ b/src/Core/Ast/AstMap/ReferenceBuilder.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace Qossmic\Deptrac\Core\Ast\AstMap;
 
+use Qossmic\Deptrac\Contract\Ast\DependencyType;
 use Qossmic\Deptrac\Contract\Ast\FileOccurrence;
 use Qossmic\Deptrac\Core\Ast\AstMap\ClassLike\ClassLikeToken;
 use Qossmic\Deptrac\Core\Ast\AstMap\FunctionLike\FunctionLikeToken;
@@ -41,7 +42,7 @@ abstract class ReferenceBuilder
         $this->dependencies[] = new DependencyToken(
             FunctionLikeToken::fromFQCN($functionName),
             new FileOccurrence($this->filepath, $occursAtLine),
-            DependencyTokenType::UNRESOLVED_FUNCTION_CALL
+            DependencyType::UNRESOLVED_FUNCTION_CALL
         );
 
         return $this;
@@ -52,7 +53,7 @@ abstract class ReferenceBuilder
         $this->dependencies[] = new DependencyToken(
             ClassLikeToken::fromFQCN($classLikeName),
             new FileOccurrence($this->filepath, $occursAtLine),
-            DependencyTokenType::VARIABLE
+            DependencyType::VARIABLE
         );
 
         return $this;
@@ -63,7 +64,7 @@ abstract class ReferenceBuilder
         $this->dependencies[] = new DependencyToken(
             SuperGlobalToken::from($superglobalName),
             new FileOccurrence($this->filepath, $occursAtLine),
-            DependencyTokenType::SUPERGLOBAL_VARIABLE
+            DependencyType::SUPERGLOBAL_VARIABLE
         );
     }
 
@@ -72,7 +73,7 @@ abstract class ReferenceBuilder
         $this->dependencies[] = new DependencyToken(
             ClassLikeToken::fromFQCN($classLikeName),
             new FileOccurrence($this->filepath, $occursAtLine),
-            DependencyTokenType::RETURN_TYPE
+            DependencyType::RETURN_TYPE
         );
 
         return $this;
@@ -83,7 +84,7 @@ abstract class ReferenceBuilder
         $this->dependencies[] = new DependencyToken(
             ClassLikeToken::fromFQCN($classLikeName),
             new FileOccurrence($this->filepath, $occursAtLine),
-            DependencyTokenType::THROW
+            DependencyType::THROW
         );
 
         return $this;
@@ -94,7 +95,7 @@ abstract class ReferenceBuilder
         $this->dependencies[] = new DependencyToken(
             ClassLikeToken::fromFQCN($classLikeName),
             new FileOccurrence($this->filepath, $occursAtLine),
-            DependencyTokenType::ANONYMOUS_CLASS_EXTENDS
+            DependencyType::ANONYMOUS_CLASS_EXTENDS
         );
     }
 
@@ -103,7 +104,7 @@ abstract class ReferenceBuilder
         $this->dependencies[] = new DependencyToken(
             ClassLikeToken::fromFQCN($classLikeName),
             new FileOccurrence($this->filepath, $occursAtLine),
-            DependencyTokenType::ANONYMOUS_CLASS_TRAIT
+            DependencyType::ANONYMOUS_CLASS_TRAIT
         );
     }
 
@@ -112,7 +113,7 @@ abstract class ReferenceBuilder
         $this->dependencies[] = new DependencyToken(
             ClassLikeToken::fromFQCN($classLikeName),
             new FileOccurrence($this->filepath, $occursAtLine),
-            DependencyTokenType::CONST
+            DependencyType::CONST
         );
     }
 
@@ -121,7 +122,7 @@ abstract class ReferenceBuilder
         $this->dependencies[] = new DependencyToken(
             ClassLikeToken::fromFQCN($classLikeName),
             new FileOccurrence($this->filepath, $occursAtLine),
-            DependencyTokenType::ANONYMOUS_CLASS_IMPLEMENTS
+            DependencyType::ANONYMOUS_CLASS_IMPLEMENTS
         );
     }
 
@@ -130,7 +131,7 @@ abstract class ReferenceBuilder
         $this->dependencies[] = new DependencyToken(
             ClassLikeToken::fromFQCN($classLikeName),
             new FileOccurrence($this->filepath, $occursAtLine),
-            DependencyTokenType::PARAMETER
+            DependencyType::PARAMETER
         );
 
         return $this;
@@ -141,7 +142,7 @@ abstract class ReferenceBuilder
         $this->dependencies[] = new DependencyToken(
             ClassLikeToken::fromFQCN($classLikeName),
             new FileOccurrence($this->filepath, $occursAtLine),
-            DependencyTokenType::ATTRIBUTE
+            DependencyType::ATTRIBUTE
         );
 
         return $this;
@@ -152,7 +153,7 @@ abstract class ReferenceBuilder
         $this->dependencies[] = new DependencyToken(
             ClassLikeToken::fromFQCN($classLikeName),
             new FileOccurrence($this->filepath, $occursAtLine),
-            DependencyTokenType::INSTANCEOF
+            DependencyType::INSTANCEOF
         );
 
         return $this;
@@ -163,7 +164,7 @@ abstract class ReferenceBuilder
         $this->dependencies[] = new DependencyToken(
             ClassLikeToken::fromFQCN($classLikeName),
             new FileOccurrence($this->filepath, $occursAtLine),
-            DependencyTokenType::NEW
+            DependencyType::NEW
         );
 
         return $this;
@@ -174,7 +175,7 @@ abstract class ReferenceBuilder
         $this->dependencies[] = new DependencyToken(
             ClassLikeToken::fromFQCN($classLikeName),
             new FileOccurrence($this->filepath, $occursAtLine),
-            DependencyTokenType::STATIC_PROPERTY
+            DependencyType::STATIC_PROPERTY
         );
 
         return $this;
@@ -185,7 +186,7 @@ abstract class ReferenceBuilder
         $this->dependencies[] = new DependencyToken(
             ClassLikeToken::fromFQCN($classLikeName),
             new FileOccurrence($this->filepath, $occursAtLine),
-            DependencyTokenType::STATIC_METHOD
+            DependencyType::STATIC_METHOD
         );
 
         return $this;
@@ -196,7 +197,7 @@ abstract class ReferenceBuilder
         $this->dependencies[] = new DependencyToken(
             ClassLikeToken::fromFQCN($classLikeName),
             new FileOccurrence($this->filepath, $occursAtLine),
-            DependencyTokenType::CATCH
+            DependencyType::CATCH
         );
 
         return $this;

--- a/src/Core/Dependency/Dependency.php
+++ b/src/Core/Dependency/Dependency.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace Qossmic\Deptrac\Core\Dependency;
 
+use Qossmic\Deptrac\Contract\Ast\DependencyType;
 use Qossmic\Deptrac\Contract\Ast\FileOccurrence;
 use Qossmic\Deptrac\Contract\Ast\TokenInterface;
 use Qossmic\Deptrac\Contract\Dependency\DependencyInterface;
@@ -13,7 +14,8 @@ class Dependency implements DependencyInterface
     public function __construct(
         private readonly TokenInterface $depender,
         private readonly TokenInterface $dependent,
-        private readonly FileOccurrence $fileOccurrence
+        private readonly FileOccurrence $fileOccurrence,
+        private readonly DependencyType $dependencyType
     ) {
     }
 
@@ -38,5 +40,10 @@ class Dependency implements DependencyInterface
     public function getFileOccurrence(): FileOccurrence
     {
         return $this->fileOccurrence;
+    }
+
+    public function getType(): DependencyType
+    {
+        return $this->dependencyType;
     }
 }

--- a/src/Core/Dependency/Emitter/ClassDependencyEmitter.php
+++ b/src/Core/Dependency/Emitter/ClassDependencyEmitter.php
@@ -4,8 +4,8 @@ declare(strict_types=1);
 
 namespace Qossmic\Deptrac\Core\Dependency\Emitter;
 
+use Qossmic\Deptrac\Contract\Ast\DependencyType;
 use Qossmic\Deptrac\Core\Ast\AstMap\AstMap;
-use Qossmic\Deptrac\Core\Ast\AstMap\DependencyTokenType;
 use Qossmic\Deptrac\Core\Dependency\Dependency;
 use Qossmic\Deptrac\Core\Dependency\DependencyList;
 
@@ -22,10 +22,10 @@ final class ClassDependencyEmitter implements DependencyEmitterInterface
             $classLikeName = $classReference->getToken();
 
             foreach ($classReference->dependencies as $dependency) {
-                if (DependencyTokenType::SUPERGLOBAL_VARIABLE === $dependency->type) {
+                if (DependencyType::SUPERGLOBAL_VARIABLE === $dependency->type) {
                     continue;
                 }
-                if (DependencyTokenType::UNRESOLVED_FUNCTION_CALL === $dependency->type) {
+                if (DependencyType::UNRESOLVED_FUNCTION_CALL === $dependency->type) {
                     continue;
                 }
 
@@ -33,7 +33,8 @@ final class ClassDependencyEmitter implements DependencyEmitterInterface
                     new Dependency(
                         $classLikeName,
                         $dependency->token,
-                        $dependency->fileOccurrence
+                        $dependency->fileOccurrence,
+                        $dependency->type
                     )
                 );
             }
@@ -43,7 +44,8 @@ final class ClassDependencyEmitter implements DependencyEmitterInterface
                     new Dependency(
                         $classLikeName,
                         $inherit->classLikeName,
-                        $inherit->fileOccurrence
+                        $inherit->fileOccurrence,
+                        DependencyType::INHERIT
                     )
                 );
             }

--- a/src/Core/Dependency/Emitter/ClassSuperglobalDependencyEmitter.php
+++ b/src/Core/Dependency/Emitter/ClassSuperglobalDependencyEmitter.php
@@ -4,8 +4,8 @@ declare(strict_types=1);
 
 namespace Qossmic\Deptrac\Core\Dependency\Emitter;
 
+use Qossmic\Deptrac\Contract\Ast\DependencyType;
 use Qossmic\Deptrac\Core\Ast\AstMap\AstMap;
-use Qossmic\Deptrac\Core\Ast\AstMap\DependencyTokenType;
 use Qossmic\Deptrac\Core\Dependency\Dependency;
 use Qossmic\Deptrac\Core\Dependency\DependencyList;
 
@@ -20,14 +20,15 @@ final class ClassSuperglobalDependencyEmitter implements DependencyEmitterInterf
     {
         foreach ($astMap->getClassLikeReferences() as $classReference) {
             foreach ($classReference->dependencies as $dependency) {
-                if (DependencyTokenType::SUPERGLOBAL_VARIABLE !== $dependency->type) {
+                if (DependencyType::SUPERGLOBAL_VARIABLE !== $dependency->type) {
                     continue;
                 }
                 $dependencyList->addDependency(
                     new Dependency(
                         $classReference->getToken(),
                         $dependency->token,
-                        $dependency->fileOccurrence
+                        $dependency->fileOccurrence,
+                        $dependency->type
                     )
                 );
             }

--- a/src/Core/Dependency/Emitter/FileDependencyEmitter.php
+++ b/src/Core/Dependency/Emitter/FileDependencyEmitter.php
@@ -4,8 +4,8 @@ declare(strict_types=1);
 
 namespace Qossmic\Deptrac\Core\Dependency\Emitter;
 
+use Qossmic\Deptrac\Contract\Ast\DependencyType;
 use Qossmic\Deptrac\Core\Ast\AstMap\AstMap;
-use Qossmic\Deptrac\Core\Ast\AstMap\DependencyTokenType;
 use Qossmic\Deptrac\Core\Dependency\Dependency;
 use Qossmic\Deptrac\Core\Dependency\DependencyList;
 
@@ -20,11 +20,11 @@ final class FileDependencyEmitter implements DependencyEmitterInterface
     {
         foreach ($astMap->getFileReferences() as $fileReference) {
             foreach ($fileReference->dependencies as $dependency) {
-                if (DependencyTokenType::USE === $dependency->type) {
+                if (DependencyType::USE === $dependency->type) {
                     continue;
                 }
 
-                if (DependencyTokenType::UNRESOLVED_FUNCTION_CALL === $dependency->type) {
+                if (DependencyType::UNRESOLVED_FUNCTION_CALL === $dependency->type) {
                     continue;
                 }
 
@@ -32,7 +32,8 @@ final class FileDependencyEmitter implements DependencyEmitterInterface
                     new Dependency(
                         $fileReference->getToken(),
                         $dependency->token,
-                        $dependency->fileOccurrence
+                        $dependency->fileOccurrence,
+                        $dependency->type
                     )
                 );
             }

--- a/src/Core/Dependency/Emitter/FunctionCallDependencyEmitter.php
+++ b/src/Core/Dependency/Emitter/FunctionCallDependencyEmitter.php
@@ -4,9 +4,9 @@ declare(strict_types=1);
 
 namespace Qossmic\Deptrac\Core\Dependency\Emitter;
 
+use Qossmic\Deptrac\Contract\Ast\DependencyType;
 use Qossmic\Deptrac\Core\Ast\AstMap\AstMap;
 use Qossmic\Deptrac\Core\Ast\AstMap\ClassLike\ClassLikeReference;
-use Qossmic\Deptrac\Core\Ast\AstMap\DependencyTokenType;
 use Qossmic\Deptrac\Core\Ast\AstMap\File\FileReference;
 use Qossmic\Deptrac\Core\Ast\AstMap\FunctionLike\FunctionLikeReference;
 use Qossmic\Deptrac\Core\Ast\AstMap\FunctionLike\FunctionLikeToken;
@@ -34,7 +34,7 @@ final class FunctionCallDependencyEmitter implements DependencyEmitterInterface
     {
         foreach ($references as $reference) {
             foreach ($reference->dependencies as $dependency) {
-                if (DependencyTokenType::UNRESOLVED_FUNCTION_CALL !== $dependency->type) {
+                if (DependencyType::UNRESOLVED_FUNCTION_CALL !== $dependency->type) {
                     continue;
                 }
 
@@ -46,7 +46,7 @@ final class FunctionCallDependencyEmitter implements DependencyEmitterInterface
 
                 $dependencyList->addDependency(
                     new Dependency(
-                        $reference->getToken(), $dependency->token, $dependency->fileOccurrence
+                        $reference->getToken(), $dependency->token, $dependency->fileOccurrence, $dependency->type
                     )
                 );
             }

--- a/src/Core/Dependency/Emitter/FunctionDependencyEmitter.php
+++ b/src/Core/Dependency/Emitter/FunctionDependencyEmitter.php
@@ -4,8 +4,8 @@ declare(strict_types=1);
 
 namespace Qossmic\Deptrac\Core\Dependency\Emitter;
 
+use Qossmic\Deptrac\Contract\Ast\DependencyType;
 use Qossmic\Deptrac\Core\Ast\AstMap\AstMap;
-use Qossmic\Deptrac\Core\Ast\AstMap\DependencyTokenType;
 use Qossmic\Deptrac\Core\Dependency\Dependency;
 use Qossmic\Deptrac\Core\Dependency\DependencyList;
 
@@ -21,11 +21,11 @@ final class FunctionDependencyEmitter implements DependencyEmitterInterface
         foreach ($astMap->getFileReferences() as $astFileReference) {
             foreach ($astFileReference->functionLikeReferences as $astFunctionReference) {
                 foreach ($astFunctionReference->dependencies as $dependency) {
-                    if (DependencyTokenType::SUPERGLOBAL_VARIABLE === $dependency->type) {
+                    if (DependencyType::SUPERGLOBAL_VARIABLE === $dependency->type) {
                         continue;
                     }
 
-                    if (DependencyTokenType::UNRESOLVED_FUNCTION_CALL === $dependency->type) {
+                    if (DependencyType::UNRESOLVED_FUNCTION_CALL === $dependency->type) {
                         continue;
                     }
 
@@ -33,7 +33,8 @@ final class FunctionDependencyEmitter implements DependencyEmitterInterface
                         new Dependency(
                             $astFunctionReference->getToken(),
                             $dependency->token,
-                            $dependency->fileOccurrence
+                            $dependency->fileOccurrence,
+                            $dependency->type
                         )
                     );
                 }

--- a/src/Core/Dependency/Emitter/FunctionSuperglobalDependencyEmitter.php
+++ b/src/Core/Dependency/Emitter/FunctionSuperglobalDependencyEmitter.php
@@ -4,8 +4,8 @@ declare(strict_types=1);
 
 namespace Qossmic\Deptrac\Core\Dependency\Emitter;
 
+use Qossmic\Deptrac\Contract\Ast\DependencyType;
 use Qossmic\Deptrac\Core\Ast\AstMap\AstMap;
-use Qossmic\Deptrac\Core\Ast\AstMap\DependencyTokenType;
 use Qossmic\Deptrac\Core\Dependency\Dependency;
 use Qossmic\Deptrac\Core\Dependency\DependencyList;
 
@@ -21,14 +21,15 @@ final class FunctionSuperglobalDependencyEmitter implements DependencyEmitterInt
         foreach ($astMap->getFileReferences() as $astFileReference) {
             foreach ($astFileReference->functionLikeReferences as $astFunctionReference) {
                 foreach ($astFunctionReference->dependencies as $dependency) {
-                    if (DependencyTokenType::SUPERGLOBAL_VARIABLE !== $dependency->type) {
+                    if (DependencyType::SUPERGLOBAL_VARIABLE !== $dependency->type) {
                         continue;
                     }
                     $dependencyList->addDependency(
                         new Dependency(
                             $astFunctionReference->getToken(),
                             $dependency->token,
-                            $dependency->fileOccurrence
+                            $dependency->fileOccurrence,
+                            $dependency->type
                         )
                     );
                 }

--- a/src/Core/Dependency/Emitter/UsesDependencyEmitter.php
+++ b/src/Core/Dependency/Emitter/UsesDependencyEmitter.php
@@ -4,9 +4,9 @@ declare(strict_types=1);
 
 namespace Qossmic\Deptrac\Core\Dependency\Emitter;
 
+use Qossmic\Deptrac\Contract\Ast\DependencyType;
 use Qossmic\Deptrac\Core\Ast\AstMap\AstMap;
 use Qossmic\Deptrac\Core\Ast\AstMap\DependencyToken;
-use Qossmic\Deptrac\Core\Ast\AstMap\DependencyTokenType;
 use Qossmic\Deptrac\Core\Dependency\Dependency;
 use Qossmic\Deptrac\Core\Dependency\DependencyList;
 use function array_map;
@@ -37,14 +37,15 @@ final class UsesDependencyEmitter implements DependencyEmitterInterface
         foreach ($astMap->getFileReferences() as $fileReference) {
             foreach ($fileReference->classLikeReferences as $astClassReference) {
                 foreach ($fileReference->dependencies as $emittedDependency) {
-                    if (DependencyTokenType::USE === $emittedDependency->type &&
+                    if (DependencyType::USE === $emittedDependency->type &&
                         $this->isFQDN($emittedDependency, $FQDNIndex)
                     ) {
                         $dependencyList->addDependency(
                             new Dependency(
                                 $astClassReference->getToken(),
                                 $emittedDependency->token,
-                                $emittedDependency->fileOccurrence
+                                $emittedDependency->fileOccurrence,
+                                $emittedDependency->type
                             )
                         );
                     }

--- a/src/Core/Dependency/InheritDependency.php
+++ b/src/Core/Dependency/InheritDependency.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace Qossmic\Deptrac\Core\Dependency;
 
+use Qossmic\Deptrac\Contract\Ast\DependencyType;
 use Qossmic\Deptrac\Contract\Ast\FileOccurrence;
 use Qossmic\Deptrac\Contract\Ast\TokenInterface;
 use Qossmic\Deptrac\Contract\Dependency\DependencyInterface;
@@ -46,5 +47,10 @@ class InheritDependency implements DependencyInterface
     public function getDependent(): TokenInterface
     {
         return $this->dependent;
+    }
+
+    public function getType(): DependencyType
+    {
+        return $this->originalDependency->getType();
     }
 }

--- a/src/Core/Layer/Collector/AttributeCollector.php
+++ b/src/Core/Layer/Collector/AttributeCollector.php
@@ -5,11 +5,11 @@ declare(strict_types=1);
 namespace Qossmic\Deptrac\Core\Layer\Collector;
 
 use LogicException;
+use Qossmic\Deptrac\Contract\Ast\DependencyType;
 use Qossmic\Deptrac\Contract\Ast\TokenReferenceInterface;
 use Qossmic\Deptrac\Contract\Layer\CollectorInterface;
 use Qossmic\Deptrac\Core\Ast\AstMap\AstMap;
 use Qossmic\Deptrac\Core\Ast\AstMap\ClassLike\ClassLikeReference;
-use Qossmic\Deptrac\Core\Ast\AstMap\DependencyTokenType;
 use Qossmic\Deptrac\Core\Ast\AstMap\File\FileReference;
 use Qossmic\Deptrac\Core\Ast\AstMap\FunctionLike\FunctionLikeReference;
 use function str_contains;
@@ -28,7 +28,7 @@ class AttributeCollector implements CollectorInterface
         $match = $this->getSearchedSubstring($config);
 
         foreach ($reference->dependencies as $dependency) {
-            if (DependencyTokenType::ATTRIBUTE !== $dependency->type) {
+            if (DependencyType::ATTRIBUTE !== $dependency->type) {
                 continue;
             }
 

--- a/tests/Core/Dependency/DependencyListTest.php
+++ b/tests/Core/Dependency/DependencyListTest.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace Tests\Qossmic\Deptrac\Core\Dependency;
 
 use PHPUnit\Framework\TestCase;
+use Qossmic\Deptrac\Contract\Ast\DependencyType;
 use Qossmic\Deptrac\Contract\Ast\FileOccurrence;
 use Qossmic\Deptrac\Core\Ast\AstMap\AstInherit;
 use Qossmic\Deptrac\Core\Ast\AstMap\AstInheritType;
@@ -22,9 +23,9 @@ final class DependencyListTest extends TestCase
         $classC = ClassLikeToken::fromFQCN('C');
 
         $dependencyResult = new DependencyList();
-        $dependencyResult->addDependency($dep1 = new Dependency($classA, $classB, new FileOccurrence('a.php', 12)));
-        $dependencyResult->addDependency($dep2 = new Dependency($classB, $classC, new FileOccurrence('b.php', 12)));
-        $dependencyResult->addDependency($dep3 = new Dependency($classA, $classC, new FileOccurrence('a.php', 12)));
+        $dependencyResult->addDependency($dep1 = new Dependency($classA, $classB, new FileOccurrence('a.php', 12), DependencyType::PARAMETER));
+        $dependencyResult->addDependency($dep2 = new Dependency($classB, $classC, new FileOccurrence('b.php', 12), DependencyType::PARAMETER));
+        $dependencyResult->addDependency($dep3 = new Dependency($classA, $classC, new FileOccurrence('a.php', 12), DependencyType::PARAMETER));
         self::assertSame([$dep1, $dep3], $dependencyResult->getDependenciesByClass($classA));
         self::assertSame([$dep2], $dependencyResult->getDependenciesByClass($classB));
         self::assertSame([], $dependencyResult->getDependenciesByClass($classC));
@@ -37,7 +38,7 @@ final class DependencyListTest extends TestCase
         $classB = ClassLikeToken::fromFQCN('B');
 
         $dependencyResult = new DependencyList();
-        $dependencyResult->addDependency($dep1 = new Dependency($classA, $classB, new FileOccurrence('a.php', 12)));
+        $dependencyResult->addDependency($dep1 = new Dependency($classA, $classB, new FileOccurrence('a.php', 12), DependencyType::PARAMETER));
         $dependencyResult->addInheritDependency($dep2 = new InheritDependency($classA, $classB, $dep1,
                                                                               new AstInherit(
                                                                                   $classB,

--- a/tests/Core/Dependency/DependencyTest.php
+++ b/tests/Core/Dependency/DependencyTest.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace Tests\Qossmic\Deptrac\Core\Dependency;
 
 use PHPUnit\Framework\TestCase;
+use Qossmic\Deptrac\Contract\Ast\DependencyType;
 use Qossmic\Deptrac\Contract\Ast\FileOccurrence;
 use Qossmic\Deptrac\Core\Ast\AstMap\ClassLike\ClassLikeToken;
 use Qossmic\Deptrac\Core\Dependency\Dependency;
@@ -15,7 +16,7 @@ final class DependencyTest extends TestCase
     {
         $dependency = new Dependency(
             ClassLikeToken::fromFQCN('a'),
-            ClassLikeToken::fromFQCN('b'), new FileOccurrence('/foo.php', 23)
+            ClassLikeToken::fromFQCN('b'), new FileOccurrence('/foo.php', 23), DependencyType::PARAMETER
         );
         self::assertSame('a', $dependency->getDepender()->toString());
         self::assertSame('/foo.php', $dependency->getFileOccurrence()->filepath);

--- a/tests/Core/Dependency/InheritDependencyTest.php
+++ b/tests/Core/Dependency/InheritDependencyTest.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace Tests\Qossmic\Deptrac\Core\Dependency;
 
 use PHPUnit\Framework\TestCase;
+use Qossmic\Deptrac\Contract\Ast\DependencyType;
 use Qossmic\Deptrac\Contract\Ast\FileOccurrence;
 use Qossmic\Deptrac\Core\Ast\AstMap\AstInherit;
 use Qossmic\Deptrac\Core\Ast\AstMap\AstInheritType;
@@ -23,7 +24,7 @@ final class InheritDependencyTest extends TestCase
         $dependency = new InheritDependency(
             $classLikeNameA,
             $classLikeNameB,
-            $dep = new Dependency($classLikeNameA, $classLikeNameB, $fileOccurrence),
+            $dep = new Dependency($classLikeNameA, $classLikeNameB, $fileOccurrence, DependencyType::PARAMETER),
             $astInherit = new AstInherit($classLikeNameB, $fileOccurrence, AstInheritType::EXTENDS)
         );
 

--- a/tests/Supportive/OutputFormatter/BaselineOutputFormatterTest.php
+++ b/tests/Supportive/OutputFormatter/BaselineOutputFormatterTest.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace Tests\Qossmic\Deptrac\Supportive\OutputFormatter;
 
 use PHPUnit\Framework\TestCase;
+use Qossmic\Deptrac\Contract\Ast\DependencyType;
 use Qossmic\Deptrac\Contract\Ast\FileOccurrence;
 use Qossmic\Deptrac\Contract\OutputFormatter\OutputFormatterInput;
 use Qossmic\Deptrac\Contract\Result\LegacyResult;
@@ -41,7 +42,7 @@ class BaselineOutputFormatterTest extends TestCase
                     new InheritDependency(
                         ClassLikeToken::fromFQCN('ClassA'),
                         ClassLikeToken::fromFQCN('ClassB'),
-                        new Dependency($originalA, $originalB, new FileOccurrence('originalA.php', 12)),
+                        new Dependency($originalA, $originalB, new FileOccurrence('originalA.php', 12), DependencyType::PARAMETER),
                         (new AstInherit(
                             ClassLikeToken::fromFQCN('ClassInheritA'), new FileOccurrence('originalA.php', 3),
                             AstInheritType::EXTENDS
@@ -74,7 +75,7 @@ class BaselineOutputFormatterTest extends TestCase
         yield [
             [
                 new Violation(
-                    new Dependency($originalA, $originalB, new FileOccurrence('originalA.php', 12)),
+                    new Dependency($originalA, $originalB, new FileOccurrence('originalA.php', 12), DependencyType::PARAMETER),
                     'LayerA',
                     'LayerB'
                 ),
@@ -90,7 +91,7 @@ class BaselineOutputFormatterTest extends TestCase
         yield [
             [
                 new SkippedViolation(
-                    new Dependency($originalA, $originalB, new FileOccurrence('originalA.php', 12)),
+                    new Dependency($originalA, $originalB, new FileOccurrence('originalA.php', 12), DependencyType::PARAMETER),
                     'LayerA',
                     'LayerB'
                 ),
@@ -101,7 +102,7 @@ class BaselineOutputFormatterTest extends TestCase
         yield [
             [
                 new Uncovered(
-                    new Dependency($originalA, $originalB, new FileOccurrence('originalA.php', 12)),
+                    new Dependency($originalA, $originalB, new FileOccurrence('originalA.php', 12), DependencyType::PARAMETER),
                     'LayerA'
                 ),
             ],

--- a/tests/Supportive/OutputFormatter/CodeclimateOutputFormatterTest.php
+++ b/tests/Supportive/OutputFormatter/CodeclimateOutputFormatterTest.php
@@ -6,6 +6,7 @@ namespace Tests\Qossmic\Deptrac\Supportive\OutputFormatter;
 
 use Exception;
 use PHPUnit\Framework\TestCase;
+use Qossmic\Deptrac\Contract\Ast\DependencyType;
 use Qossmic\Deptrac\Contract\Ast\FileOccurrence;
 use Qossmic\Deptrac\Contract\OutputFormatter\OutputFormatterInput;
 use Qossmic\Deptrac\Contract\Result\LegacyResult;
@@ -51,7 +52,7 @@ final class CodeclimateOutputFormatterTest extends TestCase
                         ClassLikeToken::fromFQCN('ClassB'),
                         new Dependency(
                             ClassLikeToken::fromFQCN('OriginalA'),
-                            ClassLikeToken::fromFQCN('OriginalB'), new FileOccurrence('ClassA.php', 12)
+                            ClassLikeToken::fromFQCN('OriginalB'), new FileOccurrence('ClassA.php', 12), DependencyType::PARAMETER
                         ),
                         (new AstInherit(
                             ClassLikeToken::fromFQCN('ClassInheritA'), new FileOccurrence('ClassA.php', 3),
@@ -85,7 +86,7 @@ final class CodeclimateOutputFormatterTest extends TestCase
                         ClassLikeToken::fromFQCN('ClassD'),
                         new Dependency(
                             ClassLikeToken::fromFQCN('OriginalA'),
-                            ClassLikeToken::fromFQCN('OriginalB'), new FileOccurrence('ClassC.php', 12)
+                            ClassLikeToken::fromFQCN('OriginalB'), new FileOccurrence('ClassC.php', 12), DependencyType::PARAMETER
                         ),
                         (new AstInherit(
                             ClassLikeToken::fromFQCN('ClassInheritA'), new FileOccurrence('ClassA.php', 3),
@@ -119,7 +120,7 @@ final class CodeclimateOutputFormatterTest extends TestCase
                         ClassLikeToken::fromFQCN('ClassE'),
                         new Dependency(
                             ClassLikeToken::fromFQCN('OriginalA'),
-                            ClassLikeToken::fromFQCN('OriginalB'), new FileOccurrence('ClassC.php', 15)
+                            ClassLikeToken::fromFQCN('OriginalB'), new FileOccurrence('ClassC.php', 15), DependencyType::PARAMETER
                         ),
                         (new AstInherit(
                             ClassLikeToken::fromFQCN('ClassInheritA'), new FileOccurrence('ClassA.php', 3),
@@ -156,7 +157,7 @@ final class CodeclimateOutputFormatterTest extends TestCase
                 new Violation(
                     new Dependency(
                         ClassLikeToken::fromFQCN('OriginalA'),
-                        ClassLikeToken::fromFQCN('OriginalB'), new FileOccurrence('ClassA.php', 12)
+                        ClassLikeToken::fromFQCN('OriginalB'), new FileOccurrence('ClassA.php', 12), DependencyType::PARAMETER
                     ),
                     'LayerA',
                     'LayerB'
@@ -178,7 +179,7 @@ final class CodeclimateOutputFormatterTest extends TestCase
                         ClassLikeToken::fromFQCN('ClassB'),
                         new Dependency(
                             ClassLikeToken::fromFQCN('OriginalA'),
-                            ClassLikeToken::fromFQCN('OriginalB'), new FileOccurrence('ClassA.php', 12)
+                            ClassLikeToken::fromFQCN('OriginalB'), new FileOccurrence('ClassA.php', 12), DependencyType::PARAMETER
                         ),
                         (new AstInherit(
                             ClassLikeToken::fromFQCN('ClassInheritA'), new FileOccurrence('ClassA.php', 3),
@@ -212,7 +213,7 @@ final class CodeclimateOutputFormatterTest extends TestCase
                         ClassLikeToken::fromFQCN('ClassD'),
                         new Dependency(
                             ClassLikeToken::fromFQCN('OriginalA'),
-                            ClassLikeToken::fromFQCN('OriginalB'), new FileOccurrence('ClassC.php', 12)
+                            ClassLikeToken::fromFQCN('OriginalB'), new FileOccurrence('ClassC.php', 12), DependencyType::PARAMETER
                         ),
                         (new AstInherit(
                             ClassLikeToken::fromFQCN('ClassInheritA'), new FileOccurrence('ClassA.php', 3),
@@ -252,7 +253,7 @@ final class CodeclimateOutputFormatterTest extends TestCase
                     ClassLikeToken::fromFQCN('ClassB'),
                     new Dependency(
                         ClassLikeToken::fromFQCN('OriginalA'),
-                        ClassLikeToken::fromFQCN('OriginalB'), new FileOccurrence('ClassA.php', 12)
+                        ClassLikeToken::fromFQCN('OriginalB'), new FileOccurrence('ClassA.php', 12), DependencyType::PARAMETER
                     ),
                     (new AstInherit(
                         ClassLikeToken::fromFQCN('ClassInheritA'), new FileOccurrence('ClassA.php', 3),
@@ -283,7 +284,7 @@ final class CodeclimateOutputFormatterTest extends TestCase
                     ClassLikeToken::fromFQCN('ClassB'),
                     new Dependency(
                         ClassLikeToken::fromFQCN('OriginalA'),
-                        ClassLikeToken::fromFQCN('OriginalB'), new FileOccurrence('ClassA.php', 15)
+                        ClassLikeToken::fromFQCN('OriginalB'), new FileOccurrence('ClassA.php', 15), DependencyType::PARAMETER
                     ),
                     (new AstInherit(
                         ClassLikeToken::fromFQCN('ClassInheritA'), new FileOccurrence('ClassA.php', 3),
@@ -314,7 +315,7 @@ final class CodeclimateOutputFormatterTest extends TestCase
                     ClassLikeToken::fromFQCN('ClassD'),
                     new Dependency(
                         ClassLikeToken::fromFQCN('OriginalA'),
-                        ClassLikeToken::fromFQCN('OriginalB'), new FileOccurrence('ClassC.php', 12)
+                        ClassLikeToken::fromFQCN('OriginalB'), new FileOccurrence('ClassC.php', 12), DependencyType::PARAMETER
                     ),
                     (new AstInherit(
                         ClassLikeToken::fromFQCN('ClassInheritA'), new FileOccurrence('ClassA.php', 3),
@@ -342,7 +343,7 @@ final class CodeclimateOutputFormatterTest extends TestCase
             new Uncovered(
                 new Dependency(
                     ClassLikeToken::fromFQCN('OriginalA'),
-                    ClassLikeToken::fromFQCN('OriginalB'), new FileOccurrence('OriginalA.php', 12)
+                    ClassLikeToken::fromFQCN('OriginalB'), new FileOccurrence('OriginalA.php', 12), DependencyType::PARAMETER
                 ),
                 'LayerA'
             ),
@@ -443,7 +444,7 @@ final class CodeclimateOutputFormatterTest extends TestCase
         $violation = new Violation(
             new Dependency(
                 ClassLikeToken::fromFQCN('OriginalA'),
-                ClassLikeToken::fromFQCN('OriginalB'.$malformedCharacters), new FileOccurrence('ClassA.php', 12)
+                ClassLikeToken::fromFQCN('OriginalB'.$malformedCharacters), new FileOccurrence('ClassA.php', 12), DependencyType::PARAMETER
             ),
             'LayerA',
             'LayerB'

--- a/tests/Supportive/OutputFormatter/ConsoleOutputFormatterTest.php
+++ b/tests/Supportive/OutputFormatter/ConsoleOutputFormatterTest.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace Tests\Qossmic\Deptrac\Supportive\OutputFormatter;
 
 use PHPUnit\Framework\TestCase;
+use Qossmic\Deptrac\Contract\Ast\DependencyType;
 use Qossmic\Deptrac\Contract\Ast\FileOccurrence;
 use Qossmic\Deptrac\Contract\OutputFormatter\OutputFormatterInput;
 use Qossmic\Deptrac\Contract\Result\Error;
@@ -43,7 +44,7 @@ final class ConsoleOutputFormatterTest extends TestCase
                     new InheritDependency(
                         ClassLikeToken::fromFQCN('ClassA'),
                         ClassLikeToken::fromFQCN('ClassB'),
-                        new Dependency($originalA, $originalB, new FileOccurrence('originalA.php', 12)),
+                        new Dependency($originalA, $originalB, new FileOccurrence('originalA.php', 12), DependencyType::PARAMETER),
                         (new AstInherit(
                             ClassLikeToken::fromFQCN('ClassInheritA'), new FileOccurrence('originalA.php', 3),
                             AstInheritType::EXTENDS
@@ -94,7 +95,7 @@ final class ConsoleOutputFormatterTest extends TestCase
         yield [
             [
                 new Violation(
-                    new Dependency($originalA, $originalB, new FileOccurrence('originalA.php', 12)),
+                    new Dependency($originalA, $originalB, new FileOccurrence('originalA.php', 12), DependencyType::PARAMETER),
                     'LayerA',
                     'LayerB'
                 ),
@@ -134,7 +135,7 @@ final class ConsoleOutputFormatterTest extends TestCase
         yield [
             [
                 new SkippedViolation(
-                    new Dependency($originalA, $originalB, new FileOccurrence('originalA.php', 12)),
+                    new Dependency($originalA, $originalB, new FileOccurrence('originalA.php', 12), DependencyType::PARAMETER),
                     'LayerA',
                     'LayerB'
                 ),
@@ -157,7 +158,7 @@ final class ConsoleOutputFormatterTest extends TestCase
         yield [
             [
                 new Uncovered(
-                    new Dependency($originalA, $originalB, new FileOccurrence('originalA.php', 12)),
+                    new Dependency($originalA, $originalB, new FileOccurrence('originalA.php', 12), DependencyType::PARAMETER),
                     'LayerA'
                 ),
             ],
@@ -228,7 +229,7 @@ final class ConsoleOutputFormatterTest extends TestCase
         $originalB = ClassLikeToken::fromFQCN('OriginalB');
         $rules = [
             new SkippedViolation(
-                new Dependency($originalA, $originalB, new FileOccurrence('originalA.php', 12)),
+                new Dependency($originalA, $originalB, new FileOccurrence('originalA.php', 12), DependencyType::PARAMETER),
                 'LayerA',
                 'LayerB'
             ),

--- a/tests/Supportive/OutputFormatter/GithubActionsOutputFormatterTest.php
+++ b/tests/Supportive/OutputFormatter/GithubActionsOutputFormatterTest.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace Tests\Qossmic\Deptrac\Supportive\OutputFormatter;
 
 use PHPUnit\Framework\TestCase;
+use Qossmic\Deptrac\Contract\Ast\DependencyType;
 use Qossmic\Deptrac\Contract\Ast\FileOccurrence;
 use Qossmic\Deptrac\Contract\OutputFormatter\OutputFormatterInput;
 use Qossmic\Deptrac\Contract\Result\Error;
@@ -70,7 +71,7 @@ final class GithubActionsOutputFormatterTest extends TestCase
         yield 'Simple Violation' => [
             'violations' => [
                 new Violation(
-                    new Dependency($originalA, $originalB, $originalAOccurrence),
+                    new Dependency($originalA, $originalB, $originalAOccurrence, DependencyType::PARAMETER),
                     'LayerA',
                     'LayerB'
                 ),
@@ -83,7 +84,7 @@ final class GithubActionsOutputFormatterTest extends TestCase
         yield 'Skipped Violation' => [
             'violations' => [
                 new SkippedViolation(
-                    new Dependency($originalA, $originalB, $originalAOccurrence),
+                    new Dependency($originalA, $originalB, $originalAOccurrence, DependencyType::PARAMETER),
                     'LayerA',
                     'LayerB'
                 ),
@@ -96,7 +97,7 @@ final class GithubActionsOutputFormatterTest extends TestCase
         yield 'Uncovered Dependency' => [
             'violations' => [
                 new Uncovered(
-                    new Dependency($originalA, $originalB, $originalAOccurrence),
+                    new Dependency($originalA, $originalB, $originalAOccurrence, DependencyType::PARAMETER),
                     'LayerA'
                 ),
             ],
@@ -111,7 +112,7 @@ final class GithubActionsOutputFormatterTest extends TestCase
                     new InheritDependency(
                         ClassLikeToken::fromFQCN('ClassA'),
                         ClassLikeToken::fromFQCN('ClassB'),
-                        new Dependency($originalA, $originalB, new FileOccurrence('originalA.php', 12)),
+                        new Dependency($originalA, $originalB, new FileOccurrence('originalA.php', 12), DependencyType::PARAMETER),
                         (new AstInherit(
                             ClassLikeToken::fromFQCN('ClassInheritA'), new FileOccurrence('originalA.php', 3),
                             AstInheritType::EXTENDS
@@ -168,7 +169,7 @@ final class GithubActionsOutputFormatterTest extends TestCase
 
         $rules = [
             new SkippedViolation(
-                new Dependency($originalA, $originalB, $originalAOccurrence),
+                new Dependency($originalA, $originalB, $originalAOccurrence, DependencyType::PARAMETER),
                 'LayerA',
                 'LayerB'
             ),
@@ -199,7 +200,7 @@ final class GithubActionsOutputFormatterTest extends TestCase
 
         $rules = [
             new Uncovered(
-                new Dependency($originalA, $originalB, $originalAOccurrence),
+                new Dependency($originalA, $originalB, $originalAOccurrence, DependencyType::PARAMETER),
                 'LayerA'
             ),
         ];

--- a/tests/Supportive/OutputFormatter/GraphVizDotOutputFormatterTest.php
+++ b/tests/Supportive/OutputFormatter/GraphVizDotOutputFormatterTest.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace Tests\Qossmic\Deptrac\Supportive\OutputFormatter;
 
 use PHPUnit\Framework\TestCase;
+use Qossmic\Deptrac\Contract\Ast\DependencyType;
 use Qossmic\Deptrac\Contract\Ast\FileOccurrence;
 use Qossmic\Deptrac\Contract\OutputFormatter\OutputFormatterInput;
 use Qossmic\Deptrac\Contract\Result\Allowed;
@@ -31,13 +32,13 @@ final class GraphVizDotOutputFormatterTest extends TestCase
         $classA = ClassLikeToken::fromFQCN('ClassA');
 
         $context = new LegacyResult([
-            new Violation(new Dependency($classA, ClassLikeToken::fromFQCN('ClassB'), $fileOccurrenceA), 'LayerA', 'LayerB'),
-            new Violation(new Dependency($classA, ClassLikeToken::fromFQCN('ClassHidden'), $fileOccurrenceA), 'LayerA', 'LayerHidden'),
+            new Violation(new Dependency($classA, ClassLikeToken::fromFQCN('ClassB'), $fileOccurrenceA, DependencyType::PARAMETER), 'LayerA', 'LayerB'),
+            new Violation(new Dependency($classA, ClassLikeToken::fromFQCN('ClassHidden'), $fileOccurrenceA, DependencyType::PARAMETER), 'LayerA', 'LayerHidden'),
             new Violation(new Dependency(ClassLikeToken::fromFQCN('ClassAB'), ClassLikeToken::fromFQCN('ClassBA'),
-                                         new FileOccurrence('classAB.php', 1)
+                                         new FileOccurrence('classAB.php', 1), DependencyType::PARAMETER
                           ), 'LayerA', 'LayerB'),
-            new Allowed(new Dependency($classA, ClassLikeToken::fromFQCN('ClassC'), $fileOccurrenceA), 'LayerA', 'LayerC'),
-            new Uncovered(new Dependency($classA, ClassLikeToken::fromFQCN('ClassD'), $fileOccurrenceA), 'LayerC'),
+            new Allowed(new Dependency($classA, ClassLikeToken::fromFQCN('ClassC'), $fileOccurrenceA, DependencyType::PARAMETER), 'LayerA', 'LayerC'),
+            new Uncovered(new Dependency($classA, ClassLikeToken::fromFQCN('ClassD'), $fileOccurrenceA, DependencyType::PARAMETER), 'LayerC'),
         ], [], []);
 
         $bufferedOutput = new BufferedOutput();
@@ -70,7 +71,7 @@ final class GraphVizDotOutputFormatterTest extends TestCase
 
         $dependency = new Dependency(
             ClassLikeToken::fromFQCN('ClassA'),
-            ClassLikeToken::fromFQCN('ClassC'), new FileOccurrence('classA.php', 0)
+            ClassLikeToken::fromFQCN('ClassC'), new FileOccurrence('classA.php', 0), DependencyType::PARAMETER
         );
 
         $context = new LegacyResult([
@@ -117,7 +118,7 @@ final class GraphVizDotOutputFormatterTest extends TestCase
 
         $dependency = new Dependency(
             ClassLikeToken::fromFQCN('ClassA'),
-            ClassLikeToken::fromFQCN('ClassC'), new FileOccurrence('classA.php', 0)
+            ClassLikeToken::fromFQCN('ClassC'), new FileOccurrence('classA.php', 0), DependencyType::PARAMETER
         );
 
         $context = new LegacyResult([

--- a/tests/Supportive/OutputFormatter/JUnitOutputFormatterTest.php
+++ b/tests/Supportive/OutputFormatter/JUnitOutputFormatterTest.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace Tests\Qossmic\Deptrac\Supportive\OutputFormatter;
 
 use PHPUnit\Framework\TestCase;
+use Qossmic\Deptrac\Contract\Ast\DependencyType;
 use Qossmic\Deptrac\Contract\Ast\FileOccurrence;
 use Qossmic\Deptrac\Contract\OutputFormatter\OutputFormatterInput;
 use Qossmic\Deptrac\Contract\Result\Error;
@@ -54,7 +55,7 @@ final class JUnitOutputFormatterTest extends TestCase
                     new InheritDependency(
                         ClassLikeToken::fromFQCN('ClassA'),
                         ClassLikeToken::fromFQCN('ClassB'),
-                        new Dependency($originalA, $originalB, new FileOccurrence('foo.php', 12)),
+                        new Dependency($originalA, $originalB, new FileOccurrence('foo.php', 12), DependencyType::PARAMETER),
                         (new AstInherit(
                             $classInheritA, new FileOccurrence('foo.php', 3),
                             AstInheritType::EXTENDS
@@ -83,7 +84,7 @@ final class JUnitOutputFormatterTest extends TestCase
         yield [
             [
                 new Violation(
-                    new Dependency($originalA, $originalB, new FileOccurrence('foo.php', 12)),
+                    new Dependency($originalA, $originalB, new FileOccurrence('foo.php', 12), DependencyType::PARAMETER),
                     'LayerA',
                     'LayerB'
                 ),
@@ -102,7 +103,7 @@ final class JUnitOutputFormatterTest extends TestCase
                     new InheritDependency(
                         ClassLikeToken::fromFQCN('ClassA'),
                         ClassLikeToken::fromFQCN('ClassB'),
-                        new Dependency($originalA, $originalB, new FileOccurrence('foo.php', 12)),
+                        new Dependency($originalA, $originalB, new FileOccurrence('foo.php', 12), DependencyType::PARAMETER),
                         (new AstInherit(
                             $classInheritA, new FileOccurrence('foo.php', 3),
                             AstInheritType::EXTENDS
@@ -128,7 +129,7 @@ final class JUnitOutputFormatterTest extends TestCase
                     new InheritDependency(
                         ClassLikeToken::fromFQCN('ClassC'),
                         ClassLikeToken::fromFQCN('ClassD'),
-                        new Dependency($originalA, $originalB, new FileOccurrence('foo.php', 12)),
+                        new Dependency($originalA, $originalB, new FileOccurrence('foo.php', 12), DependencyType::PARAMETER),
                         (new AstInherit(
                             $classInheritA, new FileOccurrence('foo.php', 3),
                             AstInheritType::EXTENDS

--- a/tests/Supportive/OutputFormatter/JsonOutputFormatterTest.php
+++ b/tests/Supportive/OutputFormatter/JsonOutputFormatterTest.php
@@ -6,6 +6,7 @@ namespace Tests\Qossmic\Deptrac\Supportive\OutputFormatter;
 
 use Exception;
 use PHPUnit\Framework\TestCase;
+use Qossmic\Deptrac\Contract\Ast\DependencyType;
 use Qossmic\Deptrac\Contract\Ast\FileOccurrence;
 use Qossmic\Deptrac\Contract\OutputFormatter\OutputFormatterInput;
 use Qossmic\Deptrac\Contract\Result\LegacyResult;
@@ -50,7 +51,7 @@ final class JsonOutputFormatterTest extends TestCase
                         ClassLikeToken::fromFQCN('ClassB'),
                         new Dependency(
                             ClassLikeToken::fromFQCN('OriginalA'),
-                            ClassLikeToken::fromFQCN('OriginalB'), new FileOccurrence('ClassA.php', 12)
+                            ClassLikeToken::fromFQCN('OriginalB'), new FileOccurrence('ClassA.php', 12), DependencyType::PARAMETER
                         ),
                         (new AstInherit(
                             ClassLikeToken::fromFQCN('ClassInheritA'), new FileOccurrence('ClassA.php', 3),
@@ -84,7 +85,7 @@ final class JsonOutputFormatterTest extends TestCase
                         ClassLikeToken::fromFQCN('ClassD'),
                         new Dependency(
                             ClassLikeToken::fromFQCN('OriginalA'),
-                            ClassLikeToken::fromFQCN('OriginalB'), new FileOccurrence('ClassC.php', 12)
+                            ClassLikeToken::fromFQCN('OriginalB'), new FileOccurrence('ClassC.php', 12), DependencyType::PARAMETER
                         ),
                         (new AstInherit(
                             ClassLikeToken::fromFQCN('ClassInheritA'), new FileOccurrence('ClassA.php', 3),
@@ -118,7 +119,7 @@ final class JsonOutputFormatterTest extends TestCase
                         ClassLikeToken::fromFQCN('ClassE'),
                         new Dependency(
                             ClassLikeToken::fromFQCN('OriginalA'),
-                            ClassLikeToken::fromFQCN('OriginalB'), new FileOccurrence('ClassC.php', 15)
+                            ClassLikeToken::fromFQCN('OriginalB'), new FileOccurrence('ClassC.php', 15), DependencyType::PARAMETER
                         ),
                         (new AstInherit(
                             ClassLikeToken::fromFQCN('ClassInheritA'), new FileOccurrence('ClassA.php', 3),
@@ -155,7 +156,7 @@ final class JsonOutputFormatterTest extends TestCase
                 new Violation(
                     new Dependency(
                         ClassLikeToken::fromFQCN('OriginalA'),
-                        ClassLikeToken::fromFQCN('OriginalB'), new FileOccurrence('ClassA.php', 12)
+                        ClassLikeToken::fromFQCN('OriginalB'), new FileOccurrence('ClassA.php', 12), DependencyType::PARAMETER
                     ),
                     'LayerA',
                     'LayerB'
@@ -177,7 +178,7 @@ final class JsonOutputFormatterTest extends TestCase
                         ClassLikeToken::fromFQCN('ClassB'),
                         new Dependency(
                             ClassLikeToken::fromFQCN('OriginalA'),
-                            ClassLikeToken::fromFQCN('OriginalB'), new FileOccurrence('ClassA.php', 12)
+                            ClassLikeToken::fromFQCN('OriginalB'), new FileOccurrence('ClassA.php', 12), DependencyType::PARAMETER
                         ),
                         (new AstInherit(
                             ClassLikeToken::fromFQCN('ClassInheritA'), new FileOccurrence('ClassA.php', 3),
@@ -211,7 +212,7 @@ final class JsonOutputFormatterTest extends TestCase
                         ClassLikeToken::fromFQCN('ClassD'),
                         new Dependency(
                             ClassLikeToken::fromFQCN('OriginalA'),
-                            ClassLikeToken::fromFQCN('OriginalB'), new FileOccurrence('ClassC.php', 12)
+                            ClassLikeToken::fromFQCN('OriginalB'), new FileOccurrence('ClassC.php', 12), DependencyType::PARAMETER
                         ),
                         (new AstInherit(
                             ClassLikeToken::fromFQCN('ClassInheritA'), new FileOccurrence('ClassA.php', 3),
@@ -252,7 +253,7 @@ final class JsonOutputFormatterTest extends TestCase
                         ClassLikeToken::fromFQCN('ClassB'),
                         new Dependency(
                             ClassLikeToken::fromFQCN('OriginalA'),
-                            ClassLikeToken::fromFQCN('OriginalB'), new FileOccurrence('ClassA.php', 12)
+                            ClassLikeToken::fromFQCN('OriginalB'), new FileOccurrence('ClassA.php', 12), DependencyType::PARAMETER
                         ),
                         (new AstInherit(
                             ClassLikeToken::fromFQCN('ClassInheritA'), new FileOccurrence('ClassA.php', 3),
@@ -286,7 +287,7 @@ final class JsonOutputFormatterTest extends TestCase
                         ClassLikeToken::fromFQCN('ClassB'),
                         new Dependency(
                             ClassLikeToken::fromFQCN('OriginalA'),
-                            ClassLikeToken::fromFQCN('OriginalB'), new FileOccurrence('ClassA.php', 15)
+                            ClassLikeToken::fromFQCN('OriginalB'), new FileOccurrence('ClassA.php', 15), DependencyType::PARAMETER
                         ),
                         (new AstInherit(
                             ClassLikeToken::fromFQCN('ClassInheritA'), new FileOccurrence('ClassA.php', 3),
@@ -320,7 +321,7 @@ final class JsonOutputFormatterTest extends TestCase
                         ClassLikeToken::fromFQCN('ClassD'),
                         new Dependency(
                             ClassLikeToken::fromFQCN('OriginalA'),
-                            ClassLikeToken::fromFQCN('OriginalB'), new FileOccurrence('ClassC.php', 12)
+                            ClassLikeToken::fromFQCN('OriginalB'), new FileOccurrence('ClassC.php', 12), DependencyType::PARAMETER
                         ),
                         (new AstInherit(
                             ClassLikeToken::fromFQCN('ClassInheritA'), new FileOccurrence('ClassA.php', 3),
@@ -351,7 +352,7 @@ final class JsonOutputFormatterTest extends TestCase
                 new Uncovered(
                     new Dependency(
                         ClassLikeToken::fromFQCN('OriginalA'),
-                        ClassLikeToken::fromFQCN('OriginalB'), new FileOccurrence('OriginalA.php', 12)
+                        ClassLikeToken::fromFQCN('OriginalB'), new FileOccurrence('OriginalA.php', 12), DependencyType::PARAMETER
                     ),
                     'LayerA'
                 ),
@@ -429,7 +430,7 @@ final class JsonOutputFormatterTest extends TestCase
         $violation = new Violation(
             new Dependency(
                 ClassLikeToken::fromFQCN('OriginalA'),
-                ClassLikeToken::fromFQCN('OriginalB'.$malformedCharacters), new FileOccurrence('ClassA.php', 12)
+                ClassLikeToken::fromFQCN('OriginalB'.$malformedCharacters), new FileOccurrence('ClassA.php', 12), DependencyType::PARAMETER
             ),
             'LayerA',
             'LayerB'

--- a/tests/Supportive/OutputFormatter/TableOutputFormatterTest.php
+++ b/tests/Supportive/OutputFormatter/TableOutputFormatterTest.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace Tests\Qossmic\Deptrac\Supportive\OutputFormatter;
 
 use PHPUnit\Framework\TestCase;
+use Qossmic\Deptrac\Contract\Ast\DependencyType;
 use Qossmic\Deptrac\Contract\Ast\FileOccurrence;
 use Qossmic\Deptrac\Contract\OutputFormatter\OutputFormatterInput;
 use Qossmic\Deptrac\Contract\Result\Error;
@@ -43,7 +44,7 @@ class TableOutputFormatterTest extends TestCase
                     new InheritDependency(
                         ClassLikeToken::fromFQCN('ClassA'),
                         ClassLikeToken::fromFQCN('ClassB'),
-                        new Dependency($originalA, $originalB, new FileOccurrence('originalA.php', 12)),
+                        new Dependency($originalA, $originalB, new FileOccurrence('originalA.php', 12), DependencyType::PARAMETER),
                         (new AstInherit(
                             ClassLikeToken::fromFQCN('ClassInheritA'), new FileOccurrence('originalA.php', 3),
                             AstInheritType::EXTENDS
@@ -104,7 +105,7 @@ class TableOutputFormatterTest extends TestCase
         yield [
             [
                 new Violation(
-                    new Dependency($originalA, $originalB, new FileOccurrence('originalA.php', 12)),
+                    new Dependency($originalA, $originalB, new FileOccurrence('originalA.php', 12), DependencyType::PARAMETER),
                     'LayerA',
                     'LayerB'
                 ),
@@ -155,7 +156,7 @@ class TableOutputFormatterTest extends TestCase
         yield 'skipped violations' => [
             [
                 new SkippedViolation(
-                    new Dependency($originalA, $originalB, new FileOccurrence('originalA.php', 12)),
+                    new Dependency($originalA, $originalB, new FileOccurrence('originalA.php', 12), DependencyType::PARAMETER),
                     'LayerA',
                     'LayerB'
                 ),
@@ -187,7 +188,7 @@ class TableOutputFormatterTest extends TestCase
         yield 'skipped violations without reporting' => [
             [
                 new SkippedViolation(
-                    new Dependency($originalA, $originalB, new FileOccurrence('originalA.php', 12)),
+                    new Dependency($originalA, $originalB, new FileOccurrence('originalA.php', 12), DependencyType::PARAMETER),
                     'LayerA',
                     'LayerB'
                 ),
@@ -214,7 +215,7 @@ class TableOutputFormatterTest extends TestCase
         yield 'uncovered' => [
             'rules' => [
                 new Uncovered(
-                    new Dependency($originalA, $originalB, new FileOccurrence('originalA.php', 12)),
+                    new Dependency($originalA, $originalB, new FileOccurrence('originalA.php', 12), DependencyType::PARAMETER),
                     'LayerA'
                 ),
             ],
@@ -245,7 +246,7 @@ class TableOutputFormatterTest extends TestCase
         yield 'uncovered without reporting' => [
             'rules' => [
                 new Uncovered(
-                    new Dependency($originalA, $originalB, new FileOccurrence('originalA.php', 12)),
+                    new Dependency($originalA, $originalB, new FileOccurrence('originalA.php', 12), DependencyType::PARAMETER),
                     'LayerA'
                 ),
             ],

--- a/tests/Supportive/OutputFormatter/XMLOutputFormatterTest.php
+++ b/tests/Supportive/OutputFormatter/XMLOutputFormatterTest.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace Tests\Qossmic\Deptrac\Supportive\OutputFormatter;
 
 use PHPUnit\Framework\TestCase;
+use Qossmic\Deptrac\Contract\Ast\DependencyType;
 use Qossmic\Deptrac\Contract\Ast\FileOccurrence;
 use Qossmic\Deptrac\Contract\OutputFormatter\OutputFormatterInput;
 use Qossmic\Deptrac\Contract\Result\LegacyResult;
@@ -47,7 +48,7 @@ final class XMLOutputFormatterTest extends TestCase
                         ClassLikeToken::fromFQCN('ClassA'),
                         ClassLikeToken::fromFQCN('ClassB'),
                         new Dependency(ClassLikeToken::fromFQCN('OriginalA'), ClassLikeToken::fromFQCN('OriginalB'),
-                                       new FileOccurrence('ClassA.php', 12)
+                                       new FileOccurrence('ClassA.php', 12), DependencyType::PARAMETER
                         ),
                         (new AstInherit(
                             ClassLikeToken::fromFQCN('ClassInheritA'), new FileOccurrence('ClassA.php', 3),
@@ -81,7 +82,7 @@ final class XMLOutputFormatterTest extends TestCase
             [
                 new Violation(
                     new Dependency(ClassLikeToken::fromFQCN('OriginalA'), ClassLikeToken::fromFQCN('OriginalB'),
-                                   new FileOccurrence('ClassA.php', 12)
+                                   new FileOccurrence('ClassA.php', 12), DependencyType::PARAMETER
                     ),
                     'LayerA',
                     'LayerB'
@@ -102,7 +103,7 @@ final class XMLOutputFormatterTest extends TestCase
                         ClassLikeToken::fromFQCN('ClassA'),
                         ClassLikeToken::fromFQCN('ClassB'),
                         new Dependency(ClassLikeToken::fromFQCN('OriginalA'), ClassLikeToken::fromFQCN('OriginalB'),
-                                       new FileOccurrence('ClassA.php', 12)
+                                       new FileOccurrence('ClassA.php', 12), DependencyType::PARAMETER
                         ),
                         (new AstInherit(
                             ClassLikeToken::fromFQCN('ClassInheritA'), new FileOccurrence('ClassA.php', 3),
@@ -133,7 +134,7 @@ final class XMLOutputFormatterTest extends TestCase
                         ClassLikeToken::fromFQCN('ClassC'),
                         ClassLikeToken::fromFQCN('ClassD'),
                         new Dependency(ClassLikeToken::fromFQCN('OriginalA'), ClassLikeToken::fromFQCN('OriginalB'),
-                                       new FileOccurrence('ClassA.php', 12)
+                                       new FileOccurrence('ClassA.php', 12), DependencyType::PARAMETER
                         ),
                         (new AstInherit(
                             ClassLikeToken::fromFQCN('ClassInheritA'), new FileOccurrence('ClassA.php', 3),


### PR DESCRIPTION
so that it can be used by extensions.

Resolves #992 