### PR TITLE
Fix docs: use correct case in markdown filenames

### DIFF
--- a/docs/collectors.md
+++ b/docs/collectors.md
@@ -318,7 +318,7 @@ is referenced in the config file Deptrac will try to load the class in your
 project. With this you can create collectors specific for your use case.
 
 If you would like to make your collector available to others, feel free to
-[contribute](contributing.md) it by making a pull request.
+[contribute](CONTRIBUTING.md) it by making a pull request.
 
 ## Extra collector configuration
 

--- a/docs/index.md
+++ b/docs/index.md
@@ -254,7 +254,7 @@ Please feel free to improve this documentation, fix bugs, or work on a suggested
 feature by making a pull request on GitHub. Don't hesitate to ask for support,
 if you need help at any point.
 
-The [Contribution Guide](contributing.md) in the documentation contains
+The [Contribution Guide](CONTRIBUTING.md) in the documentation contains
 some advice for making a pull request with code changes.
 
 ### Code of Conduct


### PR DESCRIPTION
it fixes some broken links on https://qossmic.github.io/deptrac/