### PR TITLE
Mutation coverage improvements

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -5,7 +5,7 @@ PHP_CS_FIXER_BIN := ./vendor/bin/php-cs-fixer
 PHPSTAN_BIN	:= ./vendor/bin/phpstan
 PSALM_BIN	:= ./vendor/bin/psalm
 PHPUNIT_BIN	:= ./vendor/bin/phpunit
-INFECTION_BIN	:= ./vendor/bin/infection
+INFECTION_BIN	:= ./vendor/bin/roave-infection-static-analysis-plugin
 
 .PHONY: build composer-install tests tests-coverage gpg php-cs-check php-cs-fix phpstan
 
@@ -38,7 +38,7 @@ psalm:
 	$(PSALM_BIN)
 
 infection: composer-install
-	$(INFECTION_BIN) --threads=$(shell nproc || sysctl -n hw.ncpu || 1) --test-framework-options='--testsuite=Tests' --only-covered --min-msi=80
+	$(INFECTION_BIN) --threads=$(shell nproc || sysctl -n hw.ncpu || 1) --test-framework-options='--testsuite=Tests' --only-covered --min-msi=80 --psalm-config=psalm.xml
 
 gpg:
 	gpg --detach-sign --armor --default-key 41DDE07547459FAECFA17813B8F640134AB1782E --output deptrac.phar.asc deptrac.phar

--- a/Makefile
+++ b/Makefile
@@ -38,7 +38,7 @@ psalm:
 	$(PSALM_BIN)
 
 infection: composer-install
-	$(INFECTION_BIN) --threads=$(shell nproc || sysctl -n hw.ncpu || 1) --test-framework-options='--testsuite=Tests' --only-covered --min-msi=80 --psalm-config=psalm.xml
+	$(INFECTION_BIN) --threads=$(shell nproc || sysctl -n hw.ncpu || 1) --test-framework-options='--testsuite=Tests' --only-covered --min-msi=85 --psalm-config=psalm.xml
 
 gpg:
 	gpg --detach-sign --armor --default-key 41DDE07547459FAECFA17813B8F640134AB1782E --output deptrac.phar.asc deptrac.phar

--- a/composer.json
+++ b/composer.json
@@ -64,6 +64,7 @@
         "phpstan/phpstan": "^1.6.8",
         "phpstan/phpstan-symfony": "^1.1",
         "phpunit/phpunit": "^9.5",
+        "roave/infection-static-analysis-plugin": "^1.28",
         "vimeo/psalm": "^4.22"
     }
 }

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "444d6a1f2edec433d10c79b590e43511",
+    "content-hash": "1028a0a7333495bd91a9e34afb1009c6",
     "packages": [
         {
             "name": "composer/pcre",
@@ -2583,79 +2583,6 @@
             "time": "2022-12-27T16:44:40+00:00"
         },
         {
-            "name": "composer/package-versions-deprecated",
-            "version": "1.11.99.5",
-            "source": {
-                "type": "git",
-                "url": "https://github.com/composer/package-versions-deprecated.git",
-                "reference": "b4f54f74ef3453349c24a845d22392cd31e65f1d"
-            },
-            "dist": {
-                "type": "zip",
-                "url": "https://api.github.com/repos/composer/package-versions-deprecated/zipball/b4f54f74ef3453349c24a845d22392cd31e65f1d",
-                "reference": "b4f54f74ef3453349c24a845d22392cd31e65f1d",
-                "shasum": ""
-            },
-            "require": {
-                "composer-plugin-api": "^1.1.0 || ^2.0",
-                "php": "^7 || ^8"
-            },
-            "replace": {
-                "ocramius/package-versions": "1.11.99"
-            },
-            "require-dev": {
-                "composer/composer": "^1.9.3 || ^2.0@dev",
-                "ext-zip": "^1.13",
-                "phpunit/phpunit": "^6.5 || ^7"
-            },
-            "type": "composer-plugin",
-            "extra": {
-                "class": "PackageVersions\\Installer",
-                "branch-alias": {
-                    "dev-master": "1.x-dev"
-                }
-            },
-            "autoload": {
-                "psr-4": {
-                    "PackageVersions\\": "src/PackageVersions"
-                }
-            },
-            "notification-url": "https://packagist.org/downloads/",
-            "license": [
-                "MIT"
-            ],
-            "authors": [
-                {
-                    "name": "Marco Pivetta",
-                    "email": "ocramius@gmail.com"
-                },
-                {
-                    "name": "Jordi Boggiano",
-                    "email": "j.boggiano@seld.be"
-                }
-            ],
-            "description": "Composer plugin that provides efficient querying for installed package versions (no runtime IO)",
-            "support": {
-                "issues": "https://github.com/composer/package-versions-deprecated/issues",
-                "source": "https://github.com/composer/package-versions-deprecated/tree/1.11.99.5"
-            },
-            "funding": [
-                {
-                    "url": "https://packagist.com",
-                    "type": "custom"
-                },
-                {
-                    "url": "https://github.com/composer",
-                    "type": "github"
-                },
-                {
-                    "url": "https://tidelift.com/funding/github/packagist/composer/composer",
-                    "type": "tidelift"
-                }
-            ],
-            "time": "2022-01-17T14:14:24+00:00"
-        },
-        {
             "name": "composer/semver",
             "version": "3.3.2",
             "source": {
@@ -4095,6 +4022,68 @@
             "time": "2021-08-02T15:04:32+00:00"
         },
         {
+            "name": "ocramius/package-versions",
+            "version": "2.7.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/Ocramius/PackageVersions.git",
+                "reference": "065921ed7cb2a6861443d91138d0a4378316af8d"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/Ocramius/PackageVersions/zipball/065921ed7cb2a6861443d91138d0a4378316af8d",
+                "reference": "065921ed7cb2a6861443d91138d0a4378316af8d",
+                "shasum": ""
+            },
+            "require": {
+                "composer-runtime-api": "^2.2.0",
+                "php": "~8.1.0 || ~8.2.0"
+            },
+            "replace": {
+                "composer/package-versions-deprecated": "*"
+            },
+            "require-dev": {
+                "composer/composer": "^2.4.4",
+                "doctrine/coding-standard": "^10.0.0",
+                "ext-zip": "^1.15.0",
+                "phpunit/phpunit": "^9.5.26",
+                "roave/infection-static-analysis-plugin": "^1.25.0",
+                "vimeo/psalm": "^4.29.0"
+            },
+            "type": "library",
+            "autoload": {
+                "psr-4": {
+                    "PackageVersions\\": "src/PackageVersions"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Marco Pivetta",
+                    "email": "ocramius@gmail.com"
+                }
+            ],
+            "description": "Provides efficient querying for installed package versions (no runtime IO)",
+            "support": {
+                "issues": "https://github.com/Ocramius/PackageVersions/issues",
+                "source": "https://github.com/Ocramius/PackageVersions/tree/2.7.0"
+            },
+            "funding": [
+                {
+                    "url": "https://github.com/Ocramius",
+                    "type": "github"
+                },
+                {
+                    "url": "https://tidelift.com/funding/github/packagist/ocramius/package-versions",
+                    "type": "tidelift"
+                }
+            ],
+            "time": "2022-10-31T12:51:46+00:00"
+        },
+        {
             "name": "ondram/ci-detector",
             "version": "4.1.0",
             "source": {
@@ -5118,6 +5107,57 @@
                 "source": "https://github.com/php-fig/cache/tree/3.0.0"
             },
             "time": "2021-02-03T23:26:27+00:00"
+        },
+        {
+            "name": "roave/infection-static-analysis-plugin",
+            "version": "1.28.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/Roave/infection-static-analysis-plugin.git",
+                "reference": "3724bbe9afe0dc1eddb2fb2c425d4acd64cb9c10"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/Roave/infection-static-analysis-plugin/zipball/3724bbe9afe0dc1eddb2fb2c425d4acd64cb9c10",
+                "reference": "3724bbe9afe0dc1eddb2fb2c425d4acd64cb9c10",
+                "shasum": ""
+            },
+            "require": {
+                "infection/infection": "0.26.16",
+                "ocramius/package-versions": "^2.7.0",
+                "php": "~8.1.0 || ~8.2.0",
+                "sanmai/later": "^0.1.2",
+                "vimeo/psalm": "^4.30.0 || ^5.0.0"
+            },
+            "require-dev": {
+                "doctrine/coding-standard": "^11.0.0",
+                "phpunit/phpunit": "^9.5.27"
+            },
+            "bin": [
+                "bin/roave-infection-static-analysis-plugin"
+            ],
+            "type": "library",
+            "autoload": {
+                "psr-4": {
+                    "Roave\\InfectionStaticAnalysis\\": "src/Roave/InfectionStaticAnalysis"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Marco Pivetta",
+                    "email": "ocramius@gmail.com"
+                }
+            ],
+            "description": "Static analysis on top of mutation testing - prevents escaped mutants from being invalid according to static analysis",
+            "support": {
+                "issues": "https://github.com/Roave/infection-static-analysis-plugin/issues",
+                "source": "https://github.com/Roave/infection-static-analysis-plugin/tree/1.28.0"
+            },
+            "time": "2022-12-30T16:05:23+00:00"
         },
         {
             "name": "sanmai/later",

--- a/infection.json.dist
+++ b/infection.json.dist
@@ -14,6 +14,10 @@
       "ignoreSourceCodeByRegex": [
         "trigger_deprecation.*"
       ]
-    }
+    },
+    "global-ignoreSourceCodeByRegex": [
+      "\\$output->writeLineFormatted.*"
+    ],
+    "CatchBlockRemoval": false
   }
 }

--- a/infection.json.dist
+++ b/infection.json.dist
@@ -1,14 +1,19 @@
 {
-    "timeout": 10,
-    "source": {
-        "directories": [
-            "src"
-        ]
-    },
-    "logs": {
-        "text": "infection.log"
-    },
-    "mutators": {
-        "@default": true
+  "timeout": 10,
+  "source": {
+    "directories": [
+      "src"
+    ]
+  },
+  "logs": {
+    "text": "infection.log"
+  },
+  "mutators": {
+    "@default": true,
+    "FunctionCallRemoval": {
+      "ignoreSourceCodeByRegex": [
+        "trigger_deprecation.*"
+      ]
     }
+  }
 }

--- a/src/Core/Ast/AstMap/ClassLike/ClassLikeReferenceBuilder.php
+++ b/src/Core/Ast/AstMap/ClassLike/ClassLikeReferenceBuilder.php
@@ -17,7 +17,7 @@ final class ClassLikeReferenceBuilder extends ReferenceBuilder
     /**
      * @param string[] $tokenTemplates
      */
-    protected function __construct(
+    private function __construct(
         array $tokenTemplates,
         string $filepath,
         private readonly ClassLikeToken $classLikeToken,

--- a/src/Core/Ast/AstMap/FunctionLike/FunctionLikeReferenceBuilder.php
+++ b/src/Core/Ast/AstMap/FunctionLike/FunctionLikeReferenceBuilder.php
@@ -11,7 +11,7 @@ class FunctionLikeReferenceBuilder extends ReferenceBuilder
     /**
      * @param string[] $tokenTemplates
      */
-    protected function __construct(array $tokenTemplates, string $filepath, private readonly string $functionName)
+    private function __construct(array $tokenTemplates, string $filepath, private readonly string $functionName)
     {
         parent::__construct($tokenTemplates, $filepath);
     }

--- a/src/Core/Ast/Parser/TypeResolver.php
+++ b/src/Core/Ast/Parser/TypeResolver.php
@@ -132,7 +132,7 @@ class TypeResolver
     /**
      * @return string[]
      */
-    public function resolveString(string $type, TypeScope $nameScope): array
+    protected function resolveString(string $type, TypeScope $nameScope): array
     {
         $context = new Context($nameScope->namespace, $nameScope->getUses());
         try {

--- a/src/Supportive/OutputFormatter/BaselineOutputFormatter.php
+++ b/src/Supportive/OutputFormatter/BaselineOutputFormatter.php
@@ -63,7 +63,7 @@ final class BaselineOutputFormatter implements OutputFormatterInterface
     }
 
     /**
-     * @return array<string,array<string>>
+     * @return array<string,list<string>>
      */
     private function collectViolations(LegacyResult $result): array
     {


### PR DESCRIPTION
Closes: #1020

Installed `roave-infection-static-analysis-plugin` that checks escaped mutants against static-analysis tools. If they would not pass SA, it kills them. Currently, supports only Psalm and not PHPStan