### PR TITLE
Migrated `debug:unused` command from deptrac-awesome

### DIFF
--- a/config/services.php
+++ b/config/services.php
@@ -19,6 +19,7 @@ use Qossmic\Deptrac\Core\Analyser\EventHandler\MatchingLayersHandler;
 use Qossmic\Deptrac\Core\Analyser\EventHandler\UncoveredDependentHandler;
 use Qossmic\Deptrac\Core\Analyser\EventHandler\UnmatchedSkippedViolations;
 use Qossmic\Deptrac\Core\Analyser\LayerForTokenAnalyser;
+use Qossmic\Deptrac\Core\Analyser\RulesetUsageAnalyser;
 use Qossmic\Deptrac\Core\Analyser\TokenInLayerAnalyser;
 use Qossmic\Deptrac\Core\Analyser\UnassignedTokenAnalyser;
 use Qossmic\Deptrac\Core\Ast\AstLoader;
@@ -81,6 +82,8 @@ use Qossmic\Deptrac\Supportive\Console\Command\DebugTokenCommand;
 use Qossmic\Deptrac\Supportive\Console\Command\DebugTokenRunner;
 use Qossmic\Deptrac\Supportive\Console\Command\DebugUnassignedCommand;
 use Qossmic\Deptrac\Supportive\Console\Command\DebugUnassignedRunner;
+use Qossmic\Deptrac\Supportive\Console\Command\DebugUnusedCommand;
+use Qossmic\Deptrac\Supportive\Console\Command\DebugUnusedRunner;
 use Qossmic\Deptrac\Supportive\Console\Command\InitCommand;
 use Qossmic\Deptrac\Supportive\File\Dumper;
 use Qossmic\Deptrac\Supportive\File\YmlFileLoader;
@@ -346,6 +349,10 @@ return static function (ContainerConfigurator $container): void {
         ->args([
             '$config' => param('analyser'),
         ]);
+    $services->set(RulesetUsageAnalyser::class)
+        ->args([
+            '$layers' => param('layers'),
+        ]);
 
     /*
      * OutputFormatter
@@ -433,6 +440,13 @@ return static function (ContainerConfigurator $container): void {
         ->autowire();
     $services
         ->set(DebugUnassignedCommand::class)
+        ->autowire()
+        ->tag('console.command');
+    $services
+        ->set(DebugUnusedRunner::class)
+        ->autowire();
+    $services
+        ->set(DebugUnusedCommand::class)
         ->autowire()
         ->tag('console.command');
 };

--- a/deptrac.config.php
+++ b/deptrac.config.php
@@ -72,7 +72,7 @@ return static function (DeptracConfig $config, ContainerConfigurator $containerC
             Ruleset::forLayer($console)->accesses($analyser, $outputFormatter, $dependencyInjection, $file),
             Ruleset::forLayer($dependency)->accesses($ast),
             Ruleset::forLayer($analyser)->accesses($layer, $dependency, $ast),
-            Ruleset::forLayer($outputFormatter)->accesses($console, $dependencyInjection),
+            Ruleset::forLayer($outputFormatter)->accesses($dependencyInjection),
             Ruleset::forLayer($ast)->accesses($file, $inputCollector),
             Ruleset::forLayer($inputCollector)->accesses($file),
             Ruleset::forLayer($supportive)->accesses($file),

--- a/deptrac.yaml
+++ b/deptrac.yaml
@@ -115,7 +115,6 @@ deptrac:
       - Dependency
       - Ast
     OutputFormatter:
-      - Console
       - DependencyInjection
     Ast:
       - File

--- a/docs/concepts.md
+++ b/docs/concepts.md
@@ -304,7 +304,7 @@ deptrac:
 ```
 
 *skip_violations* section contains an associative array where a
-key (`Library\LibClass`) is the name of dependant token and
+key (`Library\LibClass`) is the name of dependent token and
 values (`Core\CoreClass`) are dependency tokens.
 
 Matched violations will be marked as skipped:

--- a/docs/debugging.md
+++ b/docs/debugging.md
@@ -41,3 +41,23 @@ examples\Layer1\AnotherClassLikeAController
 examples\Layer1\SomeClass
 examples\Layer1\SomeClass2
 ```
+
+## `debug:unused`
+
+With the `debug:unused`-command you list all the rulesets that are not being used (i.e. there are no dependencies being allowed by this ruleset).
+
+You can optionally specify a limit (`--limit=<int>`) of how many times can be the ruleset used to be considered unused. This is useful
+if you want to find dependencies that are barely used and may be a prime candidate to get rid of.
+
+```bash
+php deptrac.phar debug:unused --limit=10
+
+  Analyser layer is dependent Layer layer 5 times
+  Ast layer is dependent File layer 9 times
+  Ast layer is dependent InputCollector layer 3 times
+  Console layer is dependent OutputFormatter layer 4 times
+  Console layer is dependent DependencyInjection layer 2 times
+  Console layer is dependent File layer 5 times
+  InputCollector layer is dependent File layer 3 times
+  OutputFormatter layer is dependent DependencyInjection layer 1 times
+```

--- a/src/Core/Analyser/AnalyserException.php
+++ b/src/Core/Analyser/AnalyserException.php
@@ -6,6 +6,7 @@ namespace Qossmic\Deptrac\Core\Analyser;
 
 use Qossmic\Deptrac\Contract\Ast\CouldNotParseFileException;
 use Qossmic\Deptrac\Contract\ExceptionInterface;
+use Qossmic\Deptrac\Contract\Layer\CircularReferenceException;
 use Qossmic\Deptrac\Contract\Layer\InvalidCollectorDefinitionException;
 use Qossmic\Deptrac\Contract\Layer\InvalidLayerDefinitionException;
 use Qossmic\Deptrac\Core\Ast\AstException;
@@ -43,5 +44,10 @@ final class AnalyserException extends RuntimeException implements ExceptionInter
     public static function couldNotParseFile(CouldNotParseFileException $e): self
     {
         return new self('Could not parse file.', 0, $e);
+    }
+
+    public static function circularReference(CircularReferenceException $e): self
+    {
+        return new self('Circular layer dependency.', 0, $e);
     }
 }

--- a/src/Core/Analyser/RulesetUsageAnalyser.php
+++ b/src/Core/Analyser/RulesetUsageAnalyser.php
@@ -1,0 +1,119 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Qossmic\Deptrac\Core\Analyser;
+
+use Qossmic\Deptrac\Contract\Ast\CouldNotParseFileException;
+use Qossmic\Deptrac\Contract\Layer\CircularReferenceException;
+use Qossmic\Deptrac\Contract\Layer\InvalidCollectorDefinitionException;
+use Qossmic\Deptrac\Contract\Layer\InvalidLayerDefinitionException;
+use Qossmic\Deptrac\Contract\Layer\LayerProvider;
+use Qossmic\Deptrac\Core\Ast\AstException;
+use Qossmic\Deptrac\Core\Ast\AstMapExtractor;
+use Qossmic\Deptrac\Core\Dependency\DependencyResolver;
+use Qossmic\Deptrac\Core\Dependency\InvalidEmitterConfigurationException;
+use Qossmic\Deptrac\Core\Dependency\TokenResolver;
+use Qossmic\Deptrac\Core\Dependency\UnrecognizedTokenException;
+use Qossmic\Deptrac\Core\Layer\LayerResolverInterface;
+
+class RulesetUsageAnalyser
+{
+    /**
+     * @param array<array{name:string}> $layers
+     */
+    public function __construct(
+        private readonly LayerProvider $layerProvider,
+        private readonly LayerResolverInterface $layerResolver,
+        private readonly AstMapExtractor $astMapExtractor,
+        private readonly DependencyResolver $dependencyResolver,
+        private readonly TokenResolver $tokenResolver,
+        private readonly array $layers
+    ) {
+    }
+
+    /**
+     * @return array<string, array<string, int>>
+     *
+     * @throws AnalyserException
+     */
+    public function analyse(): array
+    {
+        try {
+            return $this->findRulesetUsages($this->rulesetResolution());
+        } catch (InvalidEmitterConfigurationException $e) {
+            throw AnalyserException::invalidEmitterConfiguration($e);
+        } catch (UnrecognizedTokenException $e) {
+            throw AnalyserException::unrecognizedToken($e);
+        } catch (InvalidLayerDefinitionException $e) {
+            throw AnalyserException::invalidLayerDefinition($e);
+        } catch (InvalidCollectorDefinitionException $e) {
+            throw AnalyserException::invalidCollectorDefinition($e);
+        } catch (AstException $e) {
+            throw AnalyserException::failedAstParsing($e);
+        } catch (CouldNotParseFileException $e) {
+            throw AnalyserException::couldNotParseFile($e);
+        } catch (CircularReferenceException $e) {
+            throw AnalyserException::circularReference($e);
+        }
+    }
+
+    /**
+     * @return array<string, array<string, 0>> sourceLayer -> (targetLayer -> 0)
+     *
+     * @throws \Qossmic\Deptrac\Contract\Layer\CircularReferenceException
+     */
+    private function rulesetResolution(): array
+    {
+        $layerNames = [];
+        foreach (array_map(
+            static fn (array $layerDef): string => $layerDef['name'],
+            $this->layers
+        ) as $sourceLayerName) {
+            foreach (
+                $this->layerProvider->getAllowedLayers($sourceLayerName) as $destinationLayerName
+            ) {
+                $layerNames[$sourceLayerName][$destinationLayerName] = 0;
+            }
+        }
+
+        return $layerNames;
+    }
+
+    /**
+     * @param array<string, array<string, 0>> $rulesets
+     *
+     * @return array<string, array<string, int>>
+     *
+     * @throws \Qossmic\Deptrac\Core\Ast\AstException
+     * @throws \Qossmic\Deptrac\Contract\Ast\CouldNotParseFileException
+     * @throws \Qossmic\Deptrac\Core\Dependency\InvalidEmitterConfigurationException
+     * @throws \Qossmic\Deptrac\Contract\Layer\InvalidCollectorDefinitionException
+     * @throws \Qossmic\Deptrac\Contract\Layer\InvalidLayerDefinitionException
+     * @throws \Qossmic\Deptrac\Core\Dependency\UnrecognizedTokenException
+     */
+    private function findRulesetUsages(array $rulesets): array
+    {
+        $astMap = $this->astMapExtractor->extract();
+        $dependencyResult = $this->dependencyResolver->resolve($astMap);
+        foreach ($dependencyResult->getDependenciesAndInheritDependencies() as $dependency) {
+            $dependerLayerNames = $this->layerResolver->getLayersForReference(
+                $this->tokenResolver->resolve($dependency->getDepender(), $astMap),
+            );
+            foreach ($dependerLayerNames as $dependerLayerName => $_) {
+                $dependentLayerNames = $this->layerResolver->getLayersForReference(
+                    $this->tokenResolver->resolve($dependency->getDependent(), $astMap),
+                );
+                foreach ($dependentLayerNames as $dependentLayerName => $__) {
+                    if (array_key_exists($dependerLayerName, $rulesets)
+                        && array_key_exists($dependentLayerName, $rulesets[$dependerLayerName])
+                    ) {
+                        ++$rulesets[$dependerLayerName][$dependentLayerName];
+                    }
+                }
+            }
+        }
+
+        return $rulesets;
+    }
+}

--- a/src/Supportive/Console/Command/DebugUnusedCommand.php
+++ b/src/Supportive/Console/Command/DebugUnusedCommand.php
@@ -1,0 +1,55 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Qossmic\Deptrac\Supportive\Console\Command;
+
+use Qossmic\Deptrac\Supportive\Console\Symfony\Style;
+use Qossmic\Deptrac\Supportive\Console\Symfony\SymfonyOutput;
+use Symfony\Component\Console\Command\Command;
+use Symfony\Component\Console\Input\InputInterface;
+use Symfony\Component\Console\Input\InputOption;
+use Symfony\Component\Console\Output\OutputInterface;
+use Symfony\Component\Console\Style\SymfonyStyle;
+
+class DebugUnusedCommand extends Command
+{
+    public static $defaultName = 'debug:unused';
+    public static $defaultDescription = 'Lists unused (or barely used) layer dependencies';
+
+    public function __construct(private readonly DebugUnusedRunner $runner)
+    {
+        parent::__construct();
+    }
+
+    protected function configure(): void
+    {
+        parent::configure();
+
+        $this->addOption(
+            'limit',
+            'l',
+            InputOption::VALUE_OPTIONAL,
+            'How many times can it be used to be considered unused',
+            0
+        );
+    }
+
+    protected function execute(InputInterface $input, OutputInterface $output): int
+    {
+        $outputStyle = new Style(new SymfonyStyle($input, $output));
+        $symfonyOutput = new SymfonyOutput($output, $outputStyle);
+
+        try {
+            /** @var string $limit */
+            $limit = $input->getOption('limit');
+            $this->runner->run($symfonyOutput, (int) $limit);
+        } catch (CommandRunException $exception) {
+            $outputStyle->error($exception->getMessage());
+
+            return self::FAILURE;
+        }
+
+        return self::SUCCESS;
+    }
+}

--- a/src/Supportive/Console/Command/DebugUnusedRunner.php
+++ b/src/Supportive/Console/Command/DebugUnusedRunner.php
@@ -1,0 +1,68 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Qossmic\Deptrac\Supportive\Console\Command;
+
+use Qossmic\Deptrac\Contract\OutputFormatter\OutputInterface;
+use Qossmic\Deptrac\Core\Analyser\AnalyserException;
+use Qossmic\Deptrac\Core\Analyser\RulesetUsageAnalyser;
+
+/**
+ * @internal Should only be used by DebugUnusedCommand
+ */
+final class DebugUnusedRunner
+{
+    public function __construct(
+        private readonly RulesetUsageAnalyser $analyser
+    ) {
+    }
+
+    /**
+     * @throws CommandRunException
+     */
+    public function run(OutputInterface $output, int $limit): void
+    {
+        try {
+            $rulesetUsages = $this->analyser->analyse();
+
+            $outputTable = $this->prepareOutputTable(
+                $rulesetUsages,
+                $limit
+            );
+
+            $output->getStyle()->table(['Unused'], $outputTable);
+        } catch (AnalyserException $e) {
+            throw CommandRunException::analyserException($e);
+        }
+    }
+
+    /**
+     * @param array<string, array<string, int>> $layerNames
+     *
+     * @return array<array{string}>
+     */
+    private function prepareOutputTable(
+        array $layerNames,
+        int $limit
+    ): array {
+        $rows = [];
+        foreach ($layerNames as $dependerLayerName => $dependentLayerNames) {
+            foreach ($dependentLayerNames as $dependentLayerName => $numberOfDependencies) {
+                if ($numberOfDependencies <= $limit) {
+                    if (0 === $numberOfDependencies) {
+                        $rows[] = [
+                            "<info>{$dependerLayerName}</info> layer is not dependent on <info>{$dependentLayerName}</info>",
+                        ];
+                    } else {
+                        $rows[] = [
+                            "<info>{$dependerLayerName}</info> layer is dependent <info>{$dependentLayerName}</info> layer {$numberOfDependencies} times",
+                        ];
+                    }
+                }
+            }
+        }
+
+        return $rows;
+    }
+}


### PR DESCRIPTION
Closes: #1163 

Original source: https://github.com/Dance-Engineer/deptrac-awesome

Also fixed one typo (we use the term `dependEnt` not `dependAnt` everywhere else) and simplified the ruleset for an unused ruleset uncovered by running this exact command on `deptrac` itself