### PR TITLE
Migrated `debug:dependencies` command from deptrac-awesome

### DIFF
--- a/config/services.php
+++ b/config/services.php
@@ -18,6 +18,7 @@ use Qossmic\Deptrac\Core\Analyser\EventHandler\DependsOnPrivateLayer;
 use Qossmic\Deptrac\Core\Analyser\EventHandler\MatchingLayersHandler;
 use Qossmic\Deptrac\Core\Analyser\EventHandler\UncoveredDependentHandler;
 use Qossmic\Deptrac\Core\Analyser\EventHandler\UnmatchedSkippedViolations;
+use Qossmic\Deptrac\Core\Analyser\LayerDependenciesAnalyser;
 use Qossmic\Deptrac\Core\Analyser\LayerForTokenAnalyser;
 use Qossmic\Deptrac\Core\Analyser\TokenInLayerAnalyser;
 use Qossmic\Deptrac\Core\Analyser\UnassignedTokenAnalyser;
@@ -75,6 +76,8 @@ use Qossmic\Deptrac\Core\Layer\LayerResolver;
 use Qossmic\Deptrac\Core\Layer\LayerResolverInterface;
 use Qossmic\Deptrac\Supportive\Console\Command\AnalyseCommand;
 use Qossmic\Deptrac\Supportive\Console\Command\AnalyseRunner;
+use Qossmic\Deptrac\Supportive\Console\Command\DebugDependenciesCommand;
+use Qossmic\Deptrac\Supportive\Console\Command\DebugDependenciesRunner;
 use Qossmic\Deptrac\Supportive\Console\Command\DebugLayerCommand;
 use Qossmic\Deptrac\Supportive\Console\Command\DebugLayerRunner;
 use Qossmic\Deptrac\Supportive\Console\Command\DebugTokenCommand;
@@ -346,6 +349,7 @@ return static function (ContainerConfigurator $container): void {
         ->args([
             '$config' => param('analyser'),
         ]);
+    $services->set(LayerDependenciesAnalyser::class);
 
     /*
      * OutputFormatter
@@ -433,6 +437,13 @@ return static function (ContainerConfigurator $container): void {
         ->autowire();
     $services
         ->set(DebugUnassignedCommand::class)
+        ->autowire()
+        ->tag('console.command');
+    $services
+        ->set(DebugDependenciesRunner::class)
+        ->autowire();
+    $services
+        ->set(DebugDependenciesCommand::class)
         ->autowire()
         ->tag('console.command');
 };

--- a/docs/debugging.md
+++ b/docs/debugging.md
@@ -41,3 +41,18 @@ examples\Layer1\AnotherClassLikeAController
 examples\Layer1\SomeClass
 examples\Layer1\SomeClass2
 ```
+
+## `debug:dependencies`
+
+With the `debug:dependencies`-command you can see all dependencies of your layer. You can optionally specify a target layer to get only dependencies from one layer to the other:
+
+```bash
+php deptrac.phar debug:dependencies debug:dependencies Ast InputCollector
+
+  Qossmic\Deptrac\Core\Ast\AstMapExtractor depends on Qossmic\Deptrac\Core\InputCollector\InputCollectorInterface (InputCollector)
+  .../deptrac/src/Core/Ast/AstMapExtractor.php:15
+  Qossmic\Deptrac\Core\Ast\AstMapExtractor depends on Qossmic\Deptrac\Core\InputCollector\InputException (InputCollector)
+  .../deptrac/src/Core/Ast/AstMapExtractor.php:28
+  Qossmic\Deptrac\Core\Ast\AstException depends on Qossmic\Deptrac\Core\InputCollector\InputException (InputCollector)
+  .../deptrac/src/Core/Ast/AstException.php:13
+```

--- a/src/Core/Analyser/LayerDependenciesAnalyser.php
+++ b/src/Core/Analyser/LayerDependenciesAnalyser.php
@@ -1,0 +1,75 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Qossmic\Deptrac\Core\Analyser;
+
+use Qossmic\Deptrac\Contract\Ast\CouldNotParseFileException;
+use Qossmic\Deptrac\Contract\Layer\InvalidCollectorDefinitionException;
+use Qossmic\Deptrac\Contract\Layer\InvalidLayerDefinitionException;
+use Qossmic\Deptrac\Contract\Result\Uncovered;
+use Qossmic\Deptrac\Core\Ast\AstException;
+use Qossmic\Deptrac\Core\Ast\AstMapExtractor;
+use Qossmic\Deptrac\Core\Dependency\DependencyResolver;
+use Qossmic\Deptrac\Core\Dependency\InvalidEmitterConfigurationException;
+use Qossmic\Deptrac\Core\Dependency\TokenResolver;
+use Qossmic\Deptrac\Core\Dependency\UnrecognizedTokenException;
+use Qossmic\Deptrac\Core\Layer\LayerResolverInterface;
+
+class LayerDependenciesAnalyser
+{
+    public function __construct(
+        private readonly AstMapExtractor $astMapExtractor,
+        private readonly TokenResolver $tokenResolver,
+        private readonly DependencyResolver $dependencyResolver,
+        private readonly LayerResolverInterface $layerResolver
+    ) {
+    }
+
+    /**
+     * @return array<string, list<Uncovered>>
+     *
+     * @throws \Qossmic\Deptrac\Core\Analyser\AnalyserException
+     */
+    public function getDependencies(string $layer, ?string $targetLayer): array
+    {
+        try {
+            $result = [];
+            $astMap = $this->astMapExtractor->extract();
+            $dependencies = $this->dependencyResolver->resolve($astMap);
+            foreach ($dependencies->getDependenciesAndInheritDependencies() as $dependency) {
+                $dependerLayerNames = $this->layerResolver->getLayersForReference(
+                    $this->tokenResolver->resolve($dependency->getDepender(), $astMap),
+                );
+                if (array_key_exists($layer, $dependerLayerNames)) {
+                    $dependentLayerNames = $this->layerResolver->getLayersForReference(
+                        $this->tokenResolver->resolve($dependency->getDependent(), $astMap),
+                    );
+                    foreach ($dependentLayerNames as $dependentLayerName => $_) {
+                        if ($layer === $dependentLayerName
+                            || (null !== $targetLayer
+                                && $targetLayer !== $dependentLayerName)
+                        ) {
+                            continue;
+                        }
+                        $result[$dependentLayerName][] = new Uncovered($dependency, $dependentLayerName);
+                    }
+                }
+            }
+
+            return $result;
+        } catch (InvalidEmitterConfigurationException $e) {
+            throw AnalyserException::invalidEmitterConfiguration($e);
+        } catch (UnrecognizedTokenException $e) {
+            throw AnalyserException::unrecognizedToken($e);
+        } catch (InvalidLayerDefinitionException $e) {
+            throw AnalyserException::invalidLayerDefinition($e);
+        } catch (InvalidCollectorDefinitionException $e) {
+            throw AnalyserException::invalidCollectorDefinition($e);
+        } catch (AstException $e) {
+            throw AnalyserException::failedAstParsing($e);
+        } catch (CouldNotParseFileException $e) {
+            throw AnalyserException::couldNotParseFile($e);
+        }
+    }
+}

--- a/src/Supportive/Console/Command/DebugDependenciesCommand.php
+++ b/src/Supportive/Console/Command/DebugDependenciesCommand.php
@@ -1,0 +1,60 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Qossmic\Deptrac\Supportive\Console\Command;
+
+use Qossmic\Deptrac\Supportive\Console\Symfony\Style;
+use Qossmic\Deptrac\Supportive\Console\Symfony\SymfonyOutput;
+use Symfony\Component\Console\Command\Command;
+use Symfony\Component\Console\Input\InputArgument;
+use Symfony\Component\Console\Input\InputInterface;
+use Symfony\Component\Console\Output\OutputInterface;
+use Symfony\Component\Console\Style\SymfonyStyle;
+
+class DebugDependenciesCommand extends Command
+{
+    public static $defaultName = 'debug:dependencies';
+    public static $defaultDescription = 'List layer dependencies';
+
+    public function __construct(private readonly DebugDependenciesRunner $runner)
+    {
+        parent::__construct();
+    }
+
+    protected function configure(): void
+    {
+        parent::configure();
+
+        /** @throws void */
+        $this->addArgument('layer', InputArgument::REQUIRED, 'Layer to debug');
+        /** @throws void */
+        $this->addArgument(
+            'targetLayer',
+            InputArgument::OPTIONAL,
+            'Target layer to filter dependencies to only one layer'
+        );
+    }
+
+    protected function execute(InputInterface $input, OutputInterface $output): int
+    {
+        $outputStyle = new Style(new SymfonyStyle($input, $output));
+        $symfonyOutput = new SymfonyOutput($output, $outputStyle);
+
+        try {
+            /** @var ?string $target */
+            $target = $input->getArgument('targetLayer');
+
+            /** @var string $layer */
+            $layer = $input->getArgument('layer');
+
+            $this->runner->run($symfonyOutput, $layer, $target);
+        } catch (CommandRunException $exception) {
+            $outputStyle->error($exception->getMessage());
+
+            return self::FAILURE;
+        }
+
+        return self::SUCCESS;
+    }
+}

--- a/src/Supportive/Console/Command/DebugDependenciesRunner.php
+++ b/src/Supportive/Console/Command/DebugDependenciesRunner.php
@@ -1,0 +1,60 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Qossmic\Deptrac\Supportive\Console\Command;
+
+use Qossmic\Deptrac\Contract\OutputFormatter\OutputInterface;
+use Qossmic\Deptrac\Contract\Result\Uncovered;
+use Qossmic\Deptrac\Core\Analyser\AnalyserException;
+use Qossmic\Deptrac\Core\Analyser\LayerDependenciesAnalyser;
+
+/**
+ * @internal Should only be used by DebugDependenciesCommand
+ */
+final class DebugDependenciesRunner
+{
+    public function __construct(private readonly LayerDependenciesAnalyser $analyser)
+    {
+    }
+
+    /**
+     * @throws CommandRunException
+     */
+    public function run(OutputInterface $output, string $layer, ?string $target): void
+    {
+        try {
+            $dependencies = $this->analyser->getDependencies($layer, $target);
+            foreach ($dependencies as $targetLayer => $violations) {
+                $output->getStyle()->table(
+                    [$targetLayer],
+                    array_map(fn (Uncovered $violation): array => $this->formatRow($violation), $violations)
+                );
+            }
+        } catch (AnalyserException $e) {
+            throw CommandRunException::analyserException($e);
+        }
+    }
+
+    /**
+     * @return array<string>
+     */
+    private function formatRow(Uncovered $rule): array
+    {
+        $dependency = $rule->getDependency();
+
+        $message = sprintf(
+            '<info>%s</info> depends on <info>%s</info> (%s)',
+            $dependency->getDepender()
+                ->toString(),
+            $dependency->getDependent()
+                ->toString(),
+            $rule->layer
+        );
+
+        $fileOccurrence = $dependency->getFileOccurrence();
+        $message .= sprintf("\n%s:%d", $fileOccurrence->filepath, $fileOccurrence->line);
+
+        return [$message];
+    }
+}


### PR DESCRIPTION
Original source: https://github.com/Dance-Engineer/deptrac-awesome

It goes hand in hand with #1164 as once you have identified a ruleset that is close to being unused, you would like to know what are the few remaining places where it is being used.