### PR TITLE
#1158 - only init new ComposerFileParser once per composer.lock

### DIFF
--- a/src/Core/Layer/Collector/ComposerCollector.php
+++ b/src/Core/Layer/Collector/ComposerCollector.php
@@ -12,6 +12,11 @@ use RuntimeException;
 
 final class ComposerCollector implements CollectorInterface
 {
+    /**
+     * @var array<string, ComposerFilesParser>
+     */
+    private array $parser = [];
+
     public function __construct()
     {
     }
@@ -31,12 +36,13 @@ final class ComposerCollector implements CollectorInterface
         }
 
         try {
-            $composerFilesParser = new ComposerFilesParser($config['composerLockPath']);
+            $this->parser[$config['composerLockPath']] ??= new ComposerFilesParser($config['composerLockPath']);
+            $parser = $this->parser[$config['composerLockPath']];
         } catch (RuntimeException $exception) {
             throw new CouldNotParseFileException('Could not parse composer files.', 0, $exception);
         }
 
-        $namespaces = $composerFilesParser->autoloadableNamespacesForRequirements($config['packages'], true);
+        $namespaces = $parser->autoloadableNamespacesForRequirements($config['packages'], true);
         $token = $reference->getToken()->toString();
 
         foreach ($namespaces as $namespace) {


### PR DESCRIPTION
#1158 

We parsed the composer.lock everytime we checked via satisfy. @patrickkusebauch 
Before:
![image](https://github.com/qossmic/deptrac/assets/3352744/7d451322-54e8-4a6c-bb91-c7d8b61dc9f8)
After:
![image](https://github.com/qossmic/deptrac/assets/3352744/9d927ec4-9312-41da-ad82-12e4444ce279)
