### PR TITLE
Prevent excessive php-doc parsing in FileReferenceVisitor

### DIFF
--- a/src/Core/Ast/Parser/NikicPhpParser/FileReferenceVisitor.php
+++ b/src/Core/Ast/Parser/NikicPhpParser/FileReferenceVisitor.php
@@ -60,7 +60,14 @@ class FileReferenceVisitor extends NodeVisitorAbstract
         if (null === $docComment) {
             return [];
         }
-        $tokens = new TokenIterator($this->lexer->tokenize($docComment->getText()));
+        $docText = $docComment->getText();
+
+        // prevent expensive parsing, when not templates involved.
+        if (!str_contains($docText, '@template')) {
+            return [];
+        }
+
+        $tokens = new TokenIterator($this->lexer->tokenize($docText));
         $docNode = $this->docParser->parse($tokens);
 
         return array_map(static fn (TemplateTagValueNode $tag): string => $tag->name, $docNode->getTemplateTagValues());


### PR DESCRIPTION
<img width="508" alt="grafik" src="https://github.com/qossmic/deptrac/assets/120441/a307565e-4d35-4206-a79e-004d3fc550dc">

refs https://github.com/qossmic/deptrac/issues/1158