### PR TITLE
"deptrac" as composer bin

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -22,7 +22,7 @@ composer-install: ## Installs dependencies
 
 .PHONY: deptrac
 deptrac: ## Analyses own architecture using the default config confile
-	$(PHP_BIN) deptrac.php --config-file=deptrac.config.php --cache-file=./.cache/deptrac.cache --no-progress --ansi
+	./deptrac analyse -c deptrac.config.php --cache-file=./.cache/deptrac.cache --no-progress --ansi
 
 #generate-changelog: ## Generates a changelog file based on changes compared to remote origin
 #	gem install github_changelog_generator
@@ -60,4 +60,4 @@ tests-coverage: composer-install ## Runs tests and generate an html coverage rep
 .PHONY: tests
 tests: composer-install ## Runs tests followed by a very basic e2e-test
 	$(PHPUNIT_BIN) -c .
-	$(PHP_BIN) deptrac.php analyse --config-file=docs/examples/Fixture.depfile.yaml --no-cache
+	./deptrac analyse --config-file=docs/examples/Fixture.depfile.yaml --no-cache

--- a/composer.json
+++ b/composer.json
@@ -16,6 +16,9 @@
             "role": "maintainer"
         }
     ],
+    "bin": [
+        "deptrac"
+    ],
     "require": {
         "php": "^8.1",
         "ext-json": "*",

--- a/deptrac
+++ b/deptrac
@@ -1,0 +1,4 @@
+#!/usr/bin/env php
+<?php
+
+require_once __DIR__ . '/deptrac.php';


### PR DESCRIPTION
Add a convenient way to use the php version of deptrac.
Another nice side effect would be, that the php-config can now be named `deptrac.php`