### PR TITLE
do not crash the GraphViz formatter if no config is given

### DIFF
--- a/src/Supportive/OutputFormatter/Configuration/ConfigurationGraphViz.php
+++ b/src/Supportive/OutputFormatter/Configuration/ConfigurationGraphViz.php
@@ -7,11 +7,11 @@ namespace Qossmic\Deptrac\Supportive\OutputFormatter\Configuration;
 final class ConfigurationGraphViz
 {
     /**
-     * @param array{hidden_layers: string[], groups: array<string, string[]>, point_to_groups: bool} $arr
+     * @param array{hidden_layers?: string[], groups?: array<string, string[]>, point_to_groups?: bool} $arr
      */
     public static function fromArray(array $arr): self
     {
-        return new self($arr['hidden_layers'], $arr['groups'], $arr['point_to_groups']);
+        return new self($arr['hidden_layers'] ?? [], $arr['groups'] ?? [], $arr['point_to_groups'] ?? false);
     }
 
     /**

--- a/src/Supportive/OutputFormatter/GraphVizOutputFormatter.php
+++ b/src/Supportive/OutputFormatter/GraphVizOutputFormatter.php
@@ -26,13 +26,13 @@ use function tempnam;
 abstract class GraphVizOutputFormatter implements OutputFormatterInterface
 {
     /**
-     * @var array{hidden_layers: string[], groups: array<string, string[]>, point_to_groups: bool}
+     * @var array{hidden_layers?: string[], groups?: array<string, string[]>, point_to_groups?: bool}
      */
     private readonly array $config;
 
     public function __construct(FormatterConfiguration $config)
     {
-        /** @var array{hidden_layers: string[], groups: array<string, string[]>, point_to_groups: bool}  $extractedConfig */
+        /** @var array{hidden_layers?: string[], groups?: array<string, string[]>, point_to_groups?: bool}  $extractedConfig */
         $extractedConfig = $config->getConfigFor('graphviz');
         $this->config = $extractedConfig;
     }


### PR DESCRIPTION
PR #951 did not fully fix #949. Reason for this is that the Symfony container compiler skips loading extensions for which no configuration has been made. This in turn means that the Deptrac Configuration class is never processed and its default values are not being populated.