### PR TITLE
Composer collector exception when package does not exist 

### DIFF
--- a/src/Core/Layer/Collector/ComposerCollector.php
+++ b/src/Core/Layer/Collector/ComposerCollector.php
@@ -38,7 +38,12 @@ final class ComposerCollector implements CollectorInterface
             throw new CouldNotParseFileException('Could not parse composer files.', 0, $exception);
         }
 
-        $namespaces = $parser->autoloadableNamespacesForRequirements($config['packages'], true);
+        try {
+            $namespaces = $parser->autoloadableNamespacesForRequirements($config['packages'], true);
+        } catch (RuntimeException $e) {
+            throw InvalidCollectorDefinitionException::invalidCollectorConfiguration(sprintf('ComposerCollector has a non-existent package defined. %s', $e->getMessage()));
+        }
+
         $token = $reference->getToken()->toString();
 
         foreach ($namespaces as $namespace) {

--- a/src/Core/Layer/Collector/ComposerFilesParser.php
+++ b/src/Core/Layer/Collector/ComposerFilesParser.php
@@ -72,6 +72,8 @@ class ComposerFilesParser
      * @param string[] $requirements
      *
      * @return string[]
+     *
+     * @throws InvalidCollectorDefinitionException
      */
     public function autoloadableNamespacesForRequirements(array $requirements, bool $includeDev): array
     {
@@ -79,9 +81,7 @@ class ComposerFilesParser
 
         foreach ($requirements as $package) {
             if (!array_key_exists($package, $this->lockedPackages)) {
-                throw InvalidCollectorDefinitionException::invalidCollectorConfiguration(
-                    sprintf('ComposerCollector got a package that doesn\'t exist: "%s"', $package)
-                );
+                throw InvalidCollectorDefinitionException::invalidCollectorConfiguration(sprintf('ComposerCollector got a package that doesn\'t exist: "%s"', $package));
             }
 
             $namespaces[] = $this->extractNamespaces($this->lockedPackages[$package], $includeDev);

--- a/src/Core/Layer/Collector/ComposerFilesParser.php
+++ b/src/Core/Layer/Collector/ComposerFilesParser.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace Qossmic\Deptrac\Core\Layer\Collector;
 
 use JsonException;
+use Qossmic\Deptrac\Contract\Layer\InvalidCollectorDefinitionException;
 use RuntimeException;
 
 class ComposerFilesParser
@@ -77,6 +78,12 @@ class ComposerFilesParser
         $namespaces = [[]];
 
         foreach ($requirements as $package) {
+            if (!array_key_exists($package, $this->lockedPackages)) {
+                throw InvalidCollectorDefinitionException::invalidCollectorConfiguration(
+                    sprintf('ComposerCollector got a package that doesn\'t exist: "%s"', $package)
+                );
+            }
+
             $namespaces[] = $this->extractNamespaces($this->lockedPackages[$package], $includeDev);
         }
 

--- a/src/Core/Layer/Collector/ComposerFilesParser.php
+++ b/src/Core/Layer/Collector/ComposerFilesParser.php
@@ -5,7 +5,6 @@ declare(strict_types=1);
 namespace Qossmic\Deptrac\Core\Layer\Collector;
 
 use JsonException;
-use Qossmic\Deptrac\Contract\Layer\InvalidCollectorDefinitionException;
 use RuntimeException;
 
 class ComposerFilesParser
@@ -73,7 +72,7 @@ class ComposerFilesParser
      *
      * @return string[]
      *
-     * @throws InvalidCollectorDefinitionException
+     * @throws RuntimeException
      */
     public function autoloadableNamespacesForRequirements(array $requirements, bool $includeDev): array
     {
@@ -81,7 +80,7 @@ class ComposerFilesParser
 
         foreach ($requirements as $package) {
             if (!array_key_exists($package, $this->lockedPackages)) {
-                throw InvalidCollectorDefinitionException::invalidCollectorConfiguration(sprintf('ComposerCollector got a package that doesn\'t exist: "%s"', $package));
+                throw new RuntimeException(sprintf('Could not find a "%s" package', $package));
             }
 
             $namespaces[] = $this->extractNamespaces($this->lockedPackages[$package], $includeDev);

--- a/tests/Core/Layer/Collector/ComposerCollectorTest.php
+++ b/tests/Core/Layer/Collector/ComposerCollectorTest.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace Tests\Qossmic\Deptrac\Core\Layer\Collector;
 
 use PHPUnit\Framework\TestCase;
+use Qossmic\Deptrac\Contract\Layer\InvalidCollectorDefinitionException;
 use Qossmic\Deptrac\Core\Ast\AstMap\ClassLike\ClassLikeReference;
 use Qossmic\Deptrac\Core\Ast\AstMap\ClassLike\ClassLikeToken;
 use Qossmic\Deptrac\Core\Ast\AstMap\ClassLike\ClassLikeType;
@@ -52,5 +53,19 @@ final class ComposerCollectorTest extends TestCase
         );
 
         self::assertSame($expected, $stat);
+    }
+
+    public function testComposerPackageDoesNotExist(): void
+    {
+        $this->expectException(InvalidCollectorDefinitionException::class);
+
+        $this->sut->satisfy(
+            [
+                'composerPath' => __DIR__.DIRECTORY_SEPARATOR.'data/composer.json',
+                'composerLockPath' => __DIR__.DIRECTORY_SEPARATOR.'data/composer.lock',
+                'packages' => ['fake_package'],
+            ],
+            new ClassLikeReference(ClassLikeToken::fromFQCN(''), ClassLikeType::TYPE_CLASS),
+        );
     }
 }


### PR DESCRIPTION
Throw InvalidCollectorDefinitionException if ComposerCollector could not locate a package

Fixes: https://github.com/qossmic/deptrac/issues/1230