### PR TITLE
Configure layer internal tag

### DIFF
--- a/baseline.xml
+++ b/baseline.xml
@@ -1,25 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <files psalm-version="5.13.1@086b94371304750d1c673315321a55d15fc59015">
-  <file src="src/Contract/Config/Collector/ComposerConfig.php">
-    <ImplementedReturnTypeMismatch>
-      <code><![CDATA[array{
-     *     composerPath: string,
-     *     composerLockPath: string,
-     *     packages: list<string>,
-     *     private: bool,
-     *     type: string}]]></code>
-    </ImplementedReturnTypeMismatch>
-  </file>
-  <file src="src/Contract/Config/Collector/SuperGlobalConfig.php">
-    <ImplementedReturnTypeMismatch>
-      <code><![CDATA[array{'private': bool, 'type': string, 'value': string[]}]]></code>
-    </ImplementedReturnTypeMismatch>
-  </file>
-  <file src="src/Contract/Config/ConfigurableCollectorConfig.php">
-    <ImplementedReturnTypeMismatch>
-      <code>array{private: bool, type: string, value: string}</code>
-    </ImplementedReturnTypeMismatch>
-  </file>
   <file src="src/Contract/Result/OutputResult.php">
     <InvalidReturnStatement>
       <code><![CDATA[array_key_exists($type, $this->rules) ? array_values($this->rules[$type]) : []]]></code>

--- a/baseline.xml
+++ b/baseline.xml
@@ -1,14 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <files psalm-version="5.13.1@086b94371304750d1c673315321a55d15fc59015">
-  <file src="src/Contract/Config/Collector/BoolConfig.php">
-    <ImplementedReturnTypeMismatch>
-      <code><![CDATA[array{
-     *     must: array<array-key, array{private: bool, type: string}>|mixed,
-     *     must_not: array<array-key, array{private: bool, type: string}>|mixed,
-     *     private: bool,
-     *     type: string}]]></code>
-    </ImplementedReturnTypeMismatch>
-  </file>
   <file src="src/Contract/Config/Collector/ComposerConfig.php">
     <ImplementedReturnTypeMismatch>
       <code><![CDATA[array{

--- a/config/services.php
+++ b/config/services.php
@@ -340,7 +340,10 @@ return static function (ContainerConfigurator $container): void {
         ->tag('kernel.event_subscriber');
     $services
         ->set(DependsOnInternalToken::class)
-        ->tag('kernel.event_subscriber');
+        ->tag('kernel.event_subscriber')
+        ->args([
+            '$config' => param('analyser'),
+        ]);
     $services
         ->set(UnmatchedSkippedViolations::class)
         ->tag('kernel.event_subscriber');

--- a/config/services.php
+++ b/config/services.php
@@ -72,6 +72,7 @@ use Qossmic\Deptrac\Core\Layer\Collector\LayerCollector;
 use Qossmic\Deptrac\Core\Layer\Collector\MethodCollector;
 use Qossmic\Deptrac\Core\Layer\Collector\PhpInternalCollector;
 use Qossmic\Deptrac\Core\Layer\Collector\SuperglobalCollector;
+use Qossmic\Deptrac\Core\Layer\Collector\TagValueRegexCollector;
 use Qossmic\Deptrac\Core\Layer\Collector\TraitCollector;
 use Qossmic\Deptrac\Core\Layer\Collector\UsesCollector;
 use Qossmic\Deptrac\Core\Layer\LayerResolver;
@@ -258,6 +259,9 @@ return static function (ContainerConfigurator $container): void {
     $services
         ->set(ClassNameRegexCollector::class)
         ->tag('collector', ['type' => CollectorType::TYPE_CLASS_NAME_REGEX->value]);
+    $services
+        ->set(TagValueRegexCollector::class)
+        ->tag('collector', ['type' => CollectorType::TYPE_TAG_VALUE_REGEX->value]);
     $services
         ->set(DirectoryCollector::class)
         ->tag('collector', ['type' => CollectorType::TYPE_DIRECTORY->value]);

--- a/deptrac.config.php
+++ b/deptrac.config.php
@@ -1,7 +1,7 @@
 <?php
 
 use Internal\Qossmic\Deptrac\IgnoreDependenciesOnContract;
-use Qossmic\Deptrac\Contract\Config\Analyser;
+use Qossmic\Deptrac\Contract\Config\AnalyserConfig;
 use Qossmic\Deptrac\Contract\Config\Collector\BoolConfig;
 use Qossmic\Deptrac\Contract\Config\Collector\ComposerConfig;
 use Qossmic\Deptrac\Contract\Config\Collector\DirectoryConfig;
@@ -20,14 +20,16 @@ return static function (DeptracConfig $config, ContainerConfigurator $containerC
     $config
         ->paths('src')
         ->analyser(
-            Analyser::create()->types(
-                EmitterType::CLASS_TOKEN,
-                EmitterType::CLASS_SUPERGLOBAL_TOKEN,
-                EmitterType::FILE_TOKEN,
-                EmitterType::FUNCTION_TOKEN,
-                EmitterType::FUNCTION_SUPERGLOBAL_TOKEN,
-                EmitterType::FUNCTION_CALL
-            )
+            AnalyserConfig::create()
+                ->internalTag( '@internal' )
+                ->types(
+                    EmitterType::CLASS_TOKEN,
+                    EmitterType::CLASS_SUPERGLOBAL_TOKEN,
+                    EmitterType::FILE_TOKEN,
+                    EmitterType::FUNCTION_TOKEN,
+                    EmitterType::FUNCTION_SUPERGLOBAL_TOKEN,
+                    EmitterType::FUNCTION_CALL
+                )
         )
         ->layers(
             $analyser = Layer::withName('Analyser')->collectors(

--- a/deptrac.config.php
+++ b/deptrac.config.php
@@ -1,6 +1,7 @@
 <?php
 
 use Internal\Qossmic\Deptrac\IgnoreDependenciesOnContract;
+use Qossmic\Deptrac\Contract\Config\Analyser;
 use Qossmic\Deptrac\Contract\Config\Collector\BoolConfig;
 use Qossmic\Deptrac\Contract\Config\Collector\ComposerConfig;
 use Qossmic\Deptrac\Contract\Config\Collector\DirectoryConfig;
@@ -18,13 +19,15 @@ return static function (DeptracConfig $config, ContainerConfigurator $containerC
 
     $config
         ->paths('src')
-        ->analysers(
-            EmitterType::CLASS_TOKEN,
-            EmitterType::CLASS_SUPERGLOBAL_TOKEN,
-            EmitterType::FILE_TOKEN,
-            EmitterType::FUNCTION_TOKEN,
-            EmitterType::FUNCTION_SUPERGLOBAL_TOKEN,
-            EmitterType::FUNCTION_CALL,
+        ->analyser(
+            Analyser::create()->types(
+                EmitterType::CLASS_TOKEN,
+                EmitterType::CLASS_SUPERGLOBAL_TOKEN,
+                EmitterType::FILE_TOKEN,
+                EmitterType::FUNCTION_TOKEN,
+                EmitterType::FUNCTION_SUPERGLOBAL_TOKEN,
+                EmitterType::FUNCTION_CALL
+            )
         )
         ->layers(
             $analyser = Layer::withName('Analyser')->collectors(

--- a/deptrac.yaml
+++ b/deptrac.yaml
@@ -8,6 +8,7 @@ deptrac:
     - ./src
 
   analyser:
+    internal_tag: "@internal"
     types:
       - class
       - class_superglobal

--- a/docs/collectors.md
+++ b/docs/collectors.md
@@ -97,6 +97,31 @@ deptrac:
 Every class name that matches the regular expression becomes a part of the
 *controller* layer.
 
+## `tagValueRegex` Collector
+
+The `tagValueRegex` collector allows collecting classes and functions by
+matching the name and value of any tag in their phpdoc block, such as @internal
+or @deprecated.
+
+Any matching class will be added to the assigned layer.
+
+```yaml
+deptrac:
+  layers:
+    - name: Deprecated
+      collectors:
+        - type: tagValueRegex
+          tag: '@deprecated'
+    - name: DeprecatedSinceV2
+      collectors:
+        - type: tagValueRegex
+          tag: '@deprecated'
+          value: '/^since v2/i'
+```
+All classes tagged with "@deprecated" become part of the
+*Deprecated* layer. All classes that specify that they have been
+deprecated since v2 also become part of the *DeprecatedSinceV2* layer.
+
 ## `composer` Collector
 
 The `composer` collector allows you to define dependencies on composer `require` or `require-dev` packages that follow PSR-0 or PSR-4 autoloading convention. With this collector you can for example enforce:

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -24,7 +24,7 @@ The following table shows the available config keys for Deptrac.
 <td>
 Specifies a custom doc block tag which deptrac should use to identify layer-internal
 class-like structures. The tag <code>@deptrac-internal</code> will always be used
-for this purpose. This option allows an addition tag to be specified, such as
+for this purpose. This option allows an additional tag to be specified, such as
 <code>@layer-internal</code> or plain <code>@internal</code>.
 </td>
 <td>

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -22,17 +22,17 @@ The following table shows the available config keys for Deptrac.
 <tr>
 <td>analyser.internal_tag</td>
 <td>
-Specifies which doc block tag deptrac should use to identify layer-internal class-like tokens.
-The default is <code>"@internal"</code>. May be set to <code>null</code> to disable.
-Note that the tag <code>@deptrac-internal</code> will always be used to identify
-layer-internal class-like tokens, even if this <code>internal_tag</code> is set to <code>null</code>.
+Specifies a custom doc block tag which deptrac should use to identify layer-internal
+class-like structures. The tag <code>@deptrac-internal</code> will always be used
+for this purpose. This option allows an addition tag to be specified, such as
+<code>@layer-internal</code> or plain <code>@internal</code>.
 </td>
 <td>
 
 ```yaml
 deptrac:
   analyser:
-    internal_tag: ~
+    internal_tag: "@layer-internal"
 ```
 </td>
 </tr>

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -20,6 +20,23 @@ The following table shows the available config keys for Deptrac.
 </thead>
 <tbody>
 <tr>
+<td>analyser.internal_tag</td>
+<td>
+Specifies which doc block tag deptrac should use to identify layer-internal class-like tokens.
+The default is <code>"@internal"</code>. May be set to <code>null</code> to disable.
+Note that the tag <code>@deptrac-internal</code> will always be used to identify
+layer-internal class-like tokens, even if this <code>internal_tag</code> is set to <code>null</code>.
+</td>
+<td>
+
+```yaml
+deptrac:
+  analyser:
+    internal_tag: ~
+```
+</td>
+</tr>
+<tr>
 <td>analyser.types</td>
 <td>
 

--- a/src/Contract/Ast/TaggedTokenReferenceInterface.php
+++ b/src/Contract/Ast/TaggedTokenReferenceInterface.php
@@ -15,6 +15,4 @@ interface TaggedTokenReferenceInterface extends TokenReferenceInterface
      * @return ?list<string>
      */
     public function getTagLines(string $name): ?array;
-
-    public function getTagText(string $name): ?string;
 }

--- a/src/Contract/Ast/TaggedTokenReferenceInterface.php
+++ b/src/Contract/Ast/TaggedTokenReferenceInterface.php
@@ -1,0 +1,20 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Qossmic\Deptrac\Contract\Ast;
+
+/**
+ * Represents the AST-Token, its location, and associated tags.
+ */
+interface TaggedTokenReferenceInterface extends TokenReferenceInterface
+{
+    public function hasTag(string $name): bool;
+
+    /**
+     * @return array<string,string[]>|null
+     */
+    public function getTagLines(string $name): ?array;
+
+    public function getTagText(string $name): ?string;
+}

--- a/src/Contract/Ast/TaggedTokenReferenceInterface.php
+++ b/src/Contract/Ast/TaggedTokenReferenceInterface.php
@@ -12,7 +12,7 @@ interface TaggedTokenReferenceInterface extends TokenReferenceInterface
     public function hasTag(string $name): bool;
 
     /**
-     * @return string[]|null
+     * @return ?list<string>
      */
     public function getTagLines(string $name): ?array;
 

--- a/src/Contract/Ast/TaggedTokenReferenceInterface.php
+++ b/src/Contract/Ast/TaggedTokenReferenceInterface.php
@@ -12,7 +12,7 @@ interface TaggedTokenReferenceInterface extends TokenReferenceInterface
     public function hasTag(string $name): bool;
 
     /**
-     * @return array<string,string[]>|null
+     * @return string[]|null
      */
     public function getTagLines(string $name): ?array;
 

--- a/src/Contract/Config/Analyser.php
+++ b/src/Contract/Config/Analyser.php
@@ -22,9 +22,7 @@ final class Analyser
         $types ??= [EmitterType::CLASS_TOKEN, EmitterType::FUNCTION_TOKEN];
         $analyser->types(...$types);
 
-        if (null !== $internalTag) {
-            $analyser->internalTag($internalTag);
-        }
+        $analyser->internalTag($internalTag);
 
         return $analyser;
     }

--- a/src/Contract/Config/Analyser.php
+++ b/src/Contract/Config/Analyser.php
@@ -1,0 +1,57 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Qossmic\Deptrac\Contract\Config;
+
+final class Analyser
+{
+    /** @var array<string, EmitterType> */
+    private array $types = [];
+
+    /** @var ?string */
+    private ?string $internalTag = null;
+
+    private function __construct() {}
+
+    /** @param ?array<array-key,EmitterType> $types */
+    public static function create(array $types = null, string $internalTag = null): self
+    {
+        $analyser = new self();
+
+        $types ??= [EmitterType::CLASS_TOKEN, EmitterType::FUNCTION_TOKEN];
+        $analyser->types(...$types);
+
+        if (null !== $internalTag) {
+            $analyser->internalTag($internalTag);
+        }
+
+        return $analyser;
+    }
+
+    public function types(EmitterType ...$types): self
+    {
+        $this->types = [];
+        foreach ($types as $type) {
+            $this->types[$type->value] = $type;
+        }
+
+        return $this;
+    }
+
+    public function internalTag(?string $tag): self
+    {
+        $this->internalTag = $tag;
+
+        return $this;
+    }
+
+    /** @return array<string, mixed> */
+    public function toArray(): array
+    {
+        return [
+            'types' => array_map(static fn (EmitterType $emitterType) => $emitterType->value, $this->types),
+            'internal_tag' => $this->internalTag,
+        ];
+    }
+}

--- a/src/Contract/Config/AnalyserConfig.php
+++ b/src/Contract/Config/AnalyserConfig.php
@@ -4,7 +4,7 @@ declare(strict_types=1);
 
 namespace Qossmic\Deptrac\Contract\Config;
 
-final class Analyser
+final class AnalyserConfig
 {
     /** @var array<string, EmitterType> */
     private array $types = [];

--- a/src/Contract/Config/Collector/TagValueRegexConfig.php
+++ b/src/Contract/Config/Collector/TagValueRegexConfig.php
@@ -1,0 +1,37 @@
+<?php
+
+namespace Qossmic\Deptrac\Contract\Config\Collector;
+
+use Qossmic\Deptrac\Contract\Config\CollectorConfig;
+use Qossmic\Deptrac\Contract\Config\CollectorType;
+
+final class TagValueRegexConfig extends CollectorConfig
+{
+    protected CollectorType $collectorType = CollectorType::TYPE_TAG_VALUE_REGEX;
+
+    public function __construct(
+        private string $tag,
+        private ?string $value = null
+    ) {}
+
+    public static function create(string $tag, string $regexpr = null): self
+    {
+        return new self($tag, $regexpr);
+    }
+
+    public function match(string $regexpr): self
+    {
+        $this->value = $regexpr;
+
+        return $this;
+    }
+
+    /** @return array{'type': string, 'private': bool, 'tag': string, 'value': ?string} */
+    public function toArray(): array
+    {
+        return [
+            'tag' => $this->tag,
+            'value' => $this->value,
+        ] + parent::toArray();
+    }
+}

--- a/src/Contract/Config/Collector/TagValueRegexConfig.php
+++ b/src/Contract/Config/Collector/TagValueRegexConfig.php
@@ -26,7 +26,6 @@ final class TagValueRegexConfig extends CollectorConfig
         return $this;
     }
 
-    /** @return array{'type': string, 'private': bool, 'tag': string, 'value': ?string} */
     public function toArray(): array
     {
         return [

--- a/src/Contract/Config/CollectorConfig.php
+++ b/src/Contract/Config/CollectorConfig.php
@@ -16,7 +16,7 @@ abstract class CollectorConfig
         return $this;
     }
 
-    /** @return array{'type': string, 'private': bool} */
+    /** @return array{'type': string, 'private': bool, ...} */
     public function toArray(): array
     {
         return [

--- a/src/Contract/Config/CollectorType.php
+++ b/src/Contract/Config/CollectorType.php
@@ -12,6 +12,7 @@ enum CollectorType: string
     case TYPE_CLASS = 'class';
     case TYPE_CLASSLIKE = 'classLike';
     case TYPE_CLASS_NAME_REGEX = 'classNameRegex';
+    case TYPE_TAG_VALUE_REGEX = 'tagValueRegex';
     case TYPE_DIRECTORY = 'directory';
     case TYPE_EXTENDS = 'extends';
     case TYPE_FUNCTION_NAME = 'functionName';

--- a/src/Contract/Config/DeptracConfig.php
+++ b/src/Contract/Config/DeptracConfig.php
@@ -21,12 +21,21 @@ final class DeptracConfig implements ConfigBuilderInterface
     private array $formatters = [];
     /** @var array<Ruleset> */
     private array $rulesets = [];
+    /** @var ?string */
+    private ?string $internalTag = null;
     /** @var array<string, EmitterType> */
     private array $analyser = [];
     /** @var array<string, array<string>> */
     private array $skipViolations = [];
     /** @var array<string> */
     private array $excludeFiles = [];
+
+    public function internalTag(?string $tag): self
+    {
+        $this->internalTag = $tag;
+
+        return $this;
+    }
 
     public function analysers(EmitterType ...$types): self
     {
@@ -108,6 +117,8 @@ final class DeptracConfig implements ConfigBuilderInterface
         if ([] !== $this->paths) {
             $config['paths'] = $this->paths;
         }
+
+        $config['analyser']['internal_tag'] = $this->internalTag;
 
         if ([] !== $this->analyser) {
             $config['analyser']['types'] = array_map(static fn (EmitterType $emitterType) => $emitterType->value, $this->analyser);

--- a/src/Contract/Config/DeptracConfig.php
+++ b/src/Contract/Config/DeptracConfig.php
@@ -21,21 +21,21 @@ final class DeptracConfig implements ConfigBuilderInterface
     private array $formatters = [];
     /** @var array<Ruleset> */
     private array $rulesets = [];
-    private ?Analyser $analyser = null;
+    private ?AnalyserConfig $analyser = null;
     /** @var array<string, array<string>> */
     private array $skipViolations = [];
     /** @var array<string> */
     private array $excludeFiles = [];
 
     /**
-     * @deprecated use analyser(Analyser::create()) instead
+     * @deprecated use analyser(AnalyserConfig::create()) instead
      */
     public function analysers(EmitterType ...$types): self
     {
-        return $this->analyser(Analyser::create($types));
+        return $this->analyser(AnalyserConfig::create($types));
     }
 
-    public function analyser(Analyser $analyser): self
+    public function analyser(AnalyserConfig $analyser): self
     {
         $this->analyser = $analyser;
 

--- a/src/Contract/Config/DeptracConfig.php
+++ b/src/Contract/Config/DeptracConfig.php
@@ -21,27 +21,23 @@ final class DeptracConfig implements ConfigBuilderInterface
     private array $formatters = [];
     /** @var array<Ruleset> */
     private array $rulesets = [];
-    /** @var ?string */
-    private ?string $internalTag = null;
-    /** @var array<string, EmitterType> */
-    private array $analyser = [];
+    private ?Analyser $analyser = null;
     /** @var array<string, array<string>> */
     private array $skipViolations = [];
     /** @var array<string> */
     private array $excludeFiles = [];
 
-    public function internalTag(?string $tag): self
-    {
-        $this->internalTag = $tag;
-
-        return $this;
-    }
-
+    /**
+     * @deprecated use analyser(Analyser::create()) instead
+     */
     public function analysers(EmitterType ...$types): self
     {
-        foreach ($types as $type) {
-            $this->analyser[$type->value] = $type;
-        }
+        return $this->analyser(Analyser::create($types));
+    }
+
+    public function analyser(Analyser $analyser): self
+    {
+        $this->analyser = $analyser;
 
         return $this;
     }
@@ -118,10 +114,8 @@ final class DeptracConfig implements ConfigBuilderInterface
             $config['paths'] = $this->paths;
         }
 
-        $config['analyser']['internal_tag'] = $this->internalTag;
-
-        if ([] !== $this->analyser) {
-            $config['analyser']['types'] = array_map(static fn (EmitterType $emitterType) => $emitterType->value, $this->analyser);
+        if ($this->analyser) {
+            $config['analyser'] = $this->analyser->toArray();
         }
 
         if ([] !== $this->formatters) {

--- a/src/Core/Analyser/EventHandler/DependsOnInternalToken.php
+++ b/src/Core/Analyser/EventHandler/DependsOnInternalToken.php
@@ -29,7 +29,8 @@ class DependsOnInternalToken implements ViolationCreatingInterface
         foreach ($event->dependentLayers as $dependentLayer => $_) {
             if ($event->dependerLayer !== $dependentLayer
                 && $event->dependentReference instanceof ClassLikeReference
-                && $event->dependentReference->isInternal
+                && ($event->dependentReference->hasTag('@deptrac-internal')
+                    || $event->dependentReference->hasTag('@internal'))
             ) {
                 $this->eventHelper->addSkippableViolation($event, $ruleset, $dependentLayer, $this);
                 $event->stopPropagation();

--- a/src/Core/Analyser/EventHandler/DependsOnInternalToken.php
+++ b/src/Core/Analyser/EventHandler/DependsOnInternalToken.php
@@ -42,7 +42,7 @@ class DependsOnInternalToken implements ViolationCreatingInterface
             ) {
                 $isInternal = $event->dependentReference->hasTag('@deptrac-internal');
 
-                if (!$isInternal && $this->internalTag!==null) {
+                if (!$isInternal && null !== $this->internalTag) {
                     $isInternal = $event->dependentReference->hasTag($this->internalTag);
                 }
 

--- a/src/Core/Analyser/EventHandler/DependsOnInternalToken.php
+++ b/src/Core/Analyser/EventHandler/DependsOnInternalToken.php
@@ -42,7 +42,7 @@ class DependsOnInternalToken implements ViolationCreatingInterface
             ) {
                 $isInternal = $event->dependentReference->hasTag('@deptrac-internal');
 
-                if (!$isInternal && $this->internalTag) {
+                if (!$isInternal && $this->internalTag!==null) {
                     $isInternal = $event->dependentReference->hasTag($this->internalTag);
                 }
 

--- a/src/Core/Ast/AstMap/ClassLike/ClassLikeReference.php
+++ b/src/Core/Ast/AstMap/ClassLike/ClassLikeReference.php
@@ -4,19 +4,16 @@ declare(strict_types=1);
 
 namespace Qossmic\Deptrac\Core\Ast\AstMap\ClassLike;
 
-use Qossmic\Deptrac\Contract\Ast\TaggedTokenReferenceInterface;
 use Qossmic\Deptrac\Core\Ast\AstMap\AstInherit;
 use Qossmic\Deptrac\Core\Ast\AstMap\DependencyToken;
 use Qossmic\Deptrac\Core\Ast\AstMap\File\FileReference;
-use Qossmic\Deptrac\Core\Ast\AstMap\TaggedReferenceTrait;
+use Qossmic\Deptrac\Core\Ast\AstMap\TaggedTokenReference;
 
 /**
  * @psalm-immutable
  */
-class ClassLikeReference implements TaggedTokenReferenceInterface
+class ClassLikeReference extends TaggedTokenReference
 {
-    use TaggedReferenceTrait;
-
     public readonly ClassLikeType $type;
 
     /**
@@ -32,6 +29,7 @@ class ClassLikeReference implements TaggedTokenReferenceInterface
         public readonly array $tags = [],
         private readonly ?FileReference $fileReference = null
     ) {
+        parent::__construct($tags);
         $this->type = $classLikeType ?? ClassLikeType::TYPE_CLASSLIKE;
     }
 

--- a/src/Core/Ast/AstMap/ClassLike/ClassLikeReference.php
+++ b/src/Core/Ast/AstMap/ClassLike/ClassLikeReference.php
@@ -22,7 +22,7 @@ class ClassLikeReference implements TaggedTokenReferenceInterface
     /**
      * @param AstInherit[] $inherits
      * @param DependencyToken[] $dependencies
-     * @param array<string,string[]> $tags
+     * @param array<string,list<string>> $tags
      */
     public function __construct(
         private readonly ClassLikeToken $classLikeName,

--- a/src/Core/Ast/AstMap/ClassLike/ClassLikeReference.php
+++ b/src/Core/Ast/AstMap/ClassLike/ClassLikeReference.php
@@ -4,28 +4,32 @@ declare(strict_types=1);
 
 namespace Qossmic\Deptrac\Core\Ast\AstMap\ClassLike;
 
-use Qossmic\Deptrac\Contract\Ast\TokenReferenceInterface;
+use Qossmic\Deptrac\Contract\Ast\TaggedTokenReferenceInterface;
 use Qossmic\Deptrac\Core\Ast\AstMap\AstInherit;
 use Qossmic\Deptrac\Core\Ast\AstMap\DependencyToken;
 use Qossmic\Deptrac\Core\Ast\AstMap\File\FileReference;
+use Qossmic\Deptrac\Core\Ast\AstMap\TaggedReferenceTrait;
 
 /**
  * @psalm-immutable
  */
-class ClassLikeReference implements TokenReferenceInterface
+class ClassLikeReference implements TaggedTokenReferenceInterface
 {
+    use TaggedReferenceTrait;
+
     public readonly ClassLikeType $type;
 
     /**
      * @param AstInherit[] $inherits
      * @param DependencyToken[] $dependencies
+     * @param array<string,string[]> $tags
      */
     public function __construct(
         private readonly ClassLikeToken $classLikeName,
         ClassLikeType $classLikeType = null,
         public readonly array $inherits = [],
         public readonly array $dependencies = [],
-        public readonly bool $isInternal = false,
+        public readonly array $tags = [],
         private readonly ?FileReference $fileReference = null
     ) {
         $this->type = $classLikeType ?? ClassLikeType::TYPE_CLASSLIKE;
@@ -38,7 +42,7 @@ class ClassLikeReference implements TokenReferenceInterface
             $this->type,
             $this->inherits,
             $this->dependencies,
-            $this->isInternal,
+            $this->tags,
             $astFileReference
         );
     }

--- a/src/Core/Ast/AstMap/ClassLike/ClassLikeReferenceBuilder.php
+++ b/src/Core/Ast/AstMap/ClassLike/ClassLikeReferenceBuilder.php
@@ -16,7 +16,7 @@ final class ClassLikeReferenceBuilder extends ReferenceBuilder
 
     /**
      * @param list<string> $tokenTemplates
-     * @param array<string,string[]> $tags
+     * @param array<string,list<string>> $tags
      */
     private function __construct(
         array $tokenTemplates,
@@ -30,7 +30,7 @@ final class ClassLikeReferenceBuilder extends ReferenceBuilder
 
     /**
      * @param list<string> $classTemplates
-     * @param array<string,string[]> $tags
+     * @param array<string,list<string>> $tags
      */
     public static function createClassLike(string $filepath, string $classLikeName, array $classTemplates, array $tags): self
     {
@@ -39,7 +39,7 @@ final class ClassLikeReferenceBuilder extends ReferenceBuilder
 
     /**
      * @param list<string> $classTemplates
-     * @param array<string,string[]> $tags
+     * @param array<string,list<string>> $tags
      */
     public static function createClass(string $filepath, string $classLikeName, array $classTemplates, array $tags): self
     {
@@ -48,7 +48,7 @@ final class ClassLikeReferenceBuilder extends ReferenceBuilder
 
     /**
      * @param list<string> $classTemplates
-     * @param array<string,string[]> $tags
+     * @param array<string,list<string>> $tags
      */
     public static function createTrait(string $filepath, string $classLikeName, array $classTemplates, array $tags): self
     {
@@ -57,7 +57,7 @@ final class ClassLikeReferenceBuilder extends ReferenceBuilder
 
     /**
      * @param list<string> $classTemplates
-     * @param array<string,string[]> $tags
+     * @param array<string,list<string>> $tags
      */
     public static function createInterface(string $filepath, string $classLikeName, array $classTemplates, array $tags): self
     {

--- a/src/Core/Ast/AstMap/ClassLike/ClassLikeReferenceBuilder.php
+++ b/src/Core/Ast/AstMap/ClassLike/ClassLikeReferenceBuilder.php
@@ -16,47 +16,52 @@ final class ClassLikeReferenceBuilder extends ReferenceBuilder
 
     /**
      * @param list<string> $tokenTemplates
+     * @param array<string,string[]> $tags
      */
     private function __construct(
         array $tokenTemplates,
         string $filepath,
         private readonly ClassLikeToken $classLikeToken,
         private readonly ClassLikeType $classLikeType,
-        private readonly bool $isInternal
+        private readonly array $tags
     ) {
         parent::__construct($tokenTemplates, $filepath);
     }
 
     /**
      * @param list<string> $classTemplates
+     * @param array<string,string[]> $tags
      */
-    public static function createClassLike(string $filepath, string $classLikeName, array $classTemplates, bool $isInternal): self
+    public static function createClassLike(string $filepath, string $classLikeName, array $classTemplates, array $tags): self
     {
-        return new self($classTemplates, $filepath, ClassLikeToken::fromFQCN($classLikeName), ClassLikeType::TYPE_CLASSLIKE, $isInternal);
+        return new self($classTemplates, $filepath, ClassLikeToken::fromFQCN($classLikeName), ClassLikeType::TYPE_CLASSLIKE, $tags);
     }
 
     /**
      * @param list<string> $classTemplates
+     * @param array<string,string[]> $tags
      */
-    public static function createClass(string $filepath, string $classLikeName, array $classTemplates, bool $isInternal): self
+    public static function createClass(string $filepath, string $classLikeName, array $classTemplates, array $tags): self
     {
-        return new self($classTemplates, $filepath, ClassLikeToken::fromFQCN($classLikeName), ClassLikeType::TYPE_CLASS, $isInternal);
+        return new self($classTemplates, $filepath, ClassLikeToken::fromFQCN($classLikeName), ClassLikeType::TYPE_CLASS, $tags);
     }
 
     /**
      * @param list<string> $classTemplates
+     * @param array<string,string[]> $tags
      */
-    public static function createTrait(string $filepath, string $classLikeName, array $classTemplates, bool $isInternal): self
+    public static function createTrait(string $filepath, string $classLikeName, array $classTemplates, array $tags): self
     {
-        return new self($classTemplates, $filepath, ClassLikeToken::fromFQCN($classLikeName), ClassLikeType::TYPE_TRAIT, $isInternal);
+        return new self($classTemplates, $filepath, ClassLikeToken::fromFQCN($classLikeName), ClassLikeType::TYPE_TRAIT, $tags);
     }
 
     /**
      * @param list<string> $classTemplates
+     * @param array<string,string[]> $tags
      */
-    public static function createInterface(string $filepath, string $classLikeName, array $classTemplates, bool $isInternal): self
+    public static function createInterface(string $filepath, string $classLikeName, array $classTemplates, array $tags): self
     {
-        return new self($classTemplates, $filepath, ClassLikeToken::fromFQCN($classLikeName), ClassLikeType::TYPE_INTERFACE, $isInternal);
+        return new self($classTemplates, $filepath, ClassLikeToken::fromFQCN($classLikeName), ClassLikeType::TYPE_INTERFACE, $tags);
     }
 
     /** @internal */
@@ -67,7 +72,7 @@ final class ClassLikeReferenceBuilder extends ReferenceBuilder
             $this->classLikeType,
             $this->inherits,
             $this->dependencies,
-            $this->isInternal
+            $this->tags
         );
     }
 

--- a/src/Core/Ast/AstMap/File/FileReferenceBuilder.php
+++ b/src/Core/Ast/AstMap/File/FileReferenceBuilder.php
@@ -38,10 +38,11 @@ final class FileReferenceBuilder extends ReferenceBuilder
 
     /**
      * @param list<string> $templateTypes
+     * @param array<string,string[]> $tags
      */
-    public function newClass(string $classLikeName, array $templateTypes, bool $isInternal): ClassLikeReferenceBuilder
+    public function newClass(string $classLikeName, array $templateTypes, array $tags): ClassLikeReferenceBuilder
     {
-        $classReference = ClassLikeReferenceBuilder::createClass($this->filepath, $classLikeName, $templateTypes, $isInternal);
+        $classReference = ClassLikeReferenceBuilder::createClass($this->filepath, $classLikeName, $templateTypes, $tags);
         $this->classReferences[] = $classReference;
 
         return $classReference;
@@ -49,10 +50,11 @@ final class FileReferenceBuilder extends ReferenceBuilder
 
     /**
      * @param list<string> $templateTypes
+     * @param array<string,string[]> $tags
      */
-    public function newTrait(string $classLikeName, array $templateTypes, bool $isInternal): ClassLikeReferenceBuilder
+    public function newTrait(string $classLikeName, array $templateTypes, array $tags): ClassLikeReferenceBuilder
     {
-        $classReference = ClassLikeReferenceBuilder::createTrait($this->filepath, $classLikeName, $templateTypes, $isInternal);
+        $classReference = ClassLikeReferenceBuilder::createTrait($this->filepath, $classLikeName, $templateTypes, $tags);
         $this->classReferences[] = $classReference;
 
         return $classReference;
@@ -60,10 +62,11 @@ final class FileReferenceBuilder extends ReferenceBuilder
 
     /**
      * @param list<string> $templateTypes
+     * @param array<string,string[]> $tags
      */
-    public function newClassLike(string $classLikeName, array $templateTypes, bool $isInternal): ClassLikeReferenceBuilder
+    public function newClassLike(string $classLikeName, array $templateTypes, array $tags): ClassLikeReferenceBuilder
     {
-        $classReference = ClassLikeReferenceBuilder::createClassLike($this->filepath, $classLikeName, $templateTypes, $isInternal);
+        $classReference = ClassLikeReferenceBuilder::createClassLike($this->filepath, $classLikeName, $templateTypes, $tags);
         $this->classReferences[] = $classReference;
 
         return $classReference;
@@ -71,10 +74,11 @@ final class FileReferenceBuilder extends ReferenceBuilder
 
     /**
      * @param list<string> $templateTypes
+     * @param array<string,string[]> $tags
      */
-    public function newInterface(string $classLikeName, array $templateTypes, bool $isInternal): ClassLikeReferenceBuilder
+    public function newInterface(string $classLikeName, array $templateTypes, array $tags): ClassLikeReferenceBuilder
     {
-        $classReference = ClassLikeReferenceBuilder::createInterface($this->filepath, $classLikeName, $templateTypes, $isInternal);
+        $classReference = ClassLikeReferenceBuilder::createInterface($this->filepath, $classLikeName, $templateTypes, $tags);
         $this->classReferences[] = $classReference;
 
         return $classReference;
@@ -82,10 +86,11 @@ final class FileReferenceBuilder extends ReferenceBuilder
 
     /**
      * @param list<string> $templateTypes
+     * @param array<string,string[]> $tags
      */
-    public function newFunction(string $functionName, array $templateTypes = []): FunctionReferenceBuilder
+    public function newFunction(string $functionName, array $templateTypes = [], array $tags = []): FunctionReferenceBuilder
     {
-        $functionReference = FunctionReferenceBuilder::create($this->filepath, $functionName, $templateTypes);
+        $functionReference = FunctionReferenceBuilder::create($this->filepath, $functionName, $templateTypes, $tags);
         $this->functionReferences[] = $functionReference;
 
         return $functionReference;

--- a/src/Core/Ast/AstMap/File/FileReferenceBuilder.php
+++ b/src/Core/Ast/AstMap/File/FileReferenceBuilder.php
@@ -38,7 +38,7 @@ final class FileReferenceBuilder extends ReferenceBuilder
 
     /**
      * @param list<string> $templateTypes
-     * @param array<string,string[]> $tags
+     * @param array<string,list<string>> $tags
      */
     public function newClass(string $classLikeName, array $templateTypes, array $tags): ClassLikeReferenceBuilder
     {
@@ -50,7 +50,7 @@ final class FileReferenceBuilder extends ReferenceBuilder
 
     /**
      * @param list<string> $templateTypes
-     * @param array<string,string[]> $tags
+     * @param array<string,list<string>> $tags
      */
     public function newTrait(string $classLikeName, array $templateTypes, array $tags): ClassLikeReferenceBuilder
     {
@@ -62,7 +62,7 @@ final class FileReferenceBuilder extends ReferenceBuilder
 
     /**
      * @param list<string> $templateTypes
-     * @param array<string,string[]> $tags
+     * @param array<string,list<string>> $tags
      */
     public function newClassLike(string $classLikeName, array $templateTypes, array $tags): ClassLikeReferenceBuilder
     {
@@ -74,7 +74,7 @@ final class FileReferenceBuilder extends ReferenceBuilder
 
     /**
      * @param list<string> $templateTypes
-     * @param array<string,string[]> $tags
+     * @param array<string,list<string>> $tags
      */
     public function newInterface(string $classLikeName, array $templateTypes, array $tags): ClassLikeReferenceBuilder
     {
@@ -86,7 +86,7 @@ final class FileReferenceBuilder extends ReferenceBuilder
 
     /**
      * @param list<string> $templateTypes
-     * @param array<string,string[]> $tags
+     * @param array<string,list<string>> $tags
      */
     public function newFunction(string $functionName, array $templateTypes = [], array $tags = []): FunctionReferenceBuilder
     {

--- a/src/Core/Ast/AstMap/Function/FunctionReference.php
+++ b/src/Core/Ast/AstMap/Function/FunctionReference.php
@@ -4,22 +4,27 @@ declare(strict_types=1);
 
 namespace Qossmic\Deptrac\Core\Ast\AstMap\Function;
 
+use Qossmic\Deptrac\Contract\Ast\TaggedTokenReferenceInterface;
 use Qossmic\Deptrac\Contract\Ast\TokenInterface;
-use Qossmic\Deptrac\Contract\Ast\TokenReferenceInterface;
 use Qossmic\Deptrac\Core\Ast\AstMap\DependencyToken;
 use Qossmic\Deptrac\Core\Ast\AstMap\File\FileReference;
+use Qossmic\Deptrac\Core\Ast\AstMap\TaggedReferenceTrait;
 
 /**
  * @psalm-immutable
  */
-class FunctionReference implements TokenReferenceInterface
+class FunctionReference implements TaggedTokenReferenceInterface
 {
+    use TaggedReferenceTrait;
+
     /**
      * @param DependencyToken[] $dependencies
+     * @param array<string,string[]> $tags
      */
     public function __construct(
         private readonly FunctionToken $functionName,
         public readonly array $dependencies = [],
+        public readonly array $tags = [],
         private readonly ?FileReference $fileReference = null
     ) {}
 
@@ -28,6 +33,7 @@ class FunctionReference implements TokenReferenceInterface
         return new self(
             $this->functionName,
             $this->dependencies,
+            $this->tags,
             $astFileReference
         );
     }

--- a/src/Core/Ast/AstMap/Function/FunctionReference.php
+++ b/src/Core/Ast/AstMap/Function/FunctionReference.php
@@ -4,19 +4,16 @@ declare(strict_types=1);
 
 namespace Qossmic\Deptrac\Core\Ast\AstMap\Function;
 
-use Qossmic\Deptrac\Contract\Ast\TaggedTokenReferenceInterface;
 use Qossmic\Deptrac\Contract\Ast\TokenInterface;
 use Qossmic\Deptrac\Core\Ast\AstMap\DependencyToken;
 use Qossmic\Deptrac\Core\Ast\AstMap\File\FileReference;
-use Qossmic\Deptrac\Core\Ast\AstMap\TaggedReferenceTrait;
+use Qossmic\Deptrac\Core\Ast\AstMap\TaggedTokenReference;
 
 /**
  * @psalm-immutable
  */
-class FunctionReference implements TaggedTokenReferenceInterface
+class FunctionReference extends TaggedTokenReference
 {
-    use TaggedReferenceTrait;
-
     /**
      * @param DependencyToken[] $dependencies
      * @param array<string,list<string>> $tags
@@ -26,7 +23,9 @@ class FunctionReference implements TaggedTokenReferenceInterface
         public readonly array $dependencies = [],
         public readonly array $tags = [],
         private readonly ?FileReference $fileReference = null
-    ) {}
+    ) {
+        parent::__construct($tags);
+    }
 
     public function withFileReference(FileReference $astFileReference): self
     {

--- a/src/Core/Ast/AstMap/Function/FunctionReference.php
+++ b/src/Core/Ast/AstMap/Function/FunctionReference.php
@@ -19,7 +19,7 @@ class FunctionReference implements TaggedTokenReferenceInterface
 
     /**
      * @param DependencyToken[] $dependencies
-     * @param array<string,string[]> $tags
+     * @param array<string,list<string>> $tags
      */
     public function __construct(
         private readonly FunctionToken $functionName,

--- a/src/Core/Ast/AstMap/Function/FunctionReferenceBuilder.php
+++ b/src/Core/Ast/AstMap/Function/FunctionReferenceBuilder.php
@@ -10,7 +10,7 @@ class FunctionReferenceBuilder extends ReferenceBuilder
 {
     /**
      * @param list<string> $tokenTemplates
-     * @param array<string,string[]> $tags
+     * @param array<string,list<string>> $tags
      */
     private function __construct(
         array $tokenTemplates,
@@ -26,7 +26,7 @@ class FunctionReferenceBuilder extends ReferenceBuilder
 
     /**
      * @param list<string> $functionTemplates
-     * @param array<string,string[]> $tags
+     * @param array<string,list<string>> $tags
      */
     public static function create(string $filepath, string $functionName, array $functionTemplates, array $tags): self
     {

--- a/src/Core/Ast/AstMap/Function/FunctionReferenceBuilder.php
+++ b/src/Core/Ast/AstMap/Function/FunctionReferenceBuilder.php
@@ -10,18 +10,27 @@ class FunctionReferenceBuilder extends ReferenceBuilder
 {
     /**
      * @param list<string> $tokenTemplates
+     * @param array<string,string[]> $tags
      */
-    private function __construct(array $tokenTemplates, string $filepath, private readonly string $functionName)
-    {
-        parent::__construct($tokenTemplates, $filepath);
+    private function __construct(
+        array $tokenTemplates,
+        string $filepath,
+        private readonly string $functionName,
+        private readonly array $tags
+    ) {
+        parent::__construct(
+            $tokenTemplates,
+            $filepath
+        );
     }
 
     /**
      * @param list<string> $functionTemplates
+     * @param array<string,string[]> $tags
      */
-    public static function create(string $filepath, string $functionName, array $functionTemplates): self
+    public static function create(string $filepath, string $functionName, array $functionTemplates, array $tags): self
     {
-        return new self($functionTemplates, $filepath, $functionName);
+        return new self($functionTemplates, $filepath, $functionName, $tags);
     }
 
     /** @internal */
@@ -29,7 +38,8 @@ class FunctionReferenceBuilder extends ReferenceBuilder
     {
         return new FunctionReference(
             FunctionToken::fromFQCN($this->functionName),
-            $this->dependencies
+            $this->dependencies,
+            $this->tags
         );
     }
 }

--- a/src/Core/Ast/AstMap/TaggedReferenceTrait.php
+++ b/src/Core/Ast/AstMap/TaggedReferenceTrait.php
@@ -25,14 +25,4 @@ trait TaggedReferenceTrait
     {
         return $this->tags[$name] ?? null;
     }
-
-    public function getTagText(string $name): ?string
-    {
-        $lines = $this->getTagLines($name);
-        if ($lines) {
-            return implode("\n", $lines);
-        }
-
-        return null;
-    }
 }

--- a/src/Core/Ast/AstMap/TaggedReferenceTrait.php
+++ b/src/Core/Ast/AstMap/TaggedReferenceTrait.php
@@ -8,6 +8,8 @@ namespace Qossmic\Deptrac\Core\Ast\AstMap;
  * Helper trait for implementing TaggedTokenReferenceInterface.
  *
  * Classes that use this trait must define $this->tags as array<string,string[]>.
+ *
+ * @psalm-immutable
  */
 trait TaggedReferenceTrait
 {
@@ -26,8 +28,9 @@ trait TaggedReferenceTrait
 
     public function getTagText(string $name): ?string
     {
-        if ($this->hasTag($name)) {
-            return implode("\n", $this->getTagLines($name));
+        $lines = $this->getTagLines($name);
+        if ($lines) {
+            return implode("\n", $lines);
         }
 
         return null;

--- a/src/Core/Ast/AstMap/TaggedReferenceTrait.php
+++ b/src/Core/Ast/AstMap/TaggedReferenceTrait.php
@@ -1,0 +1,35 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Qossmic\Deptrac\Core\Ast\AstMap;
+
+/**
+ * Helper trait for implementing TaggedTokenReferenceInterface.
+ *
+ * Classes that use this trait must define $this->tags as array<string,string[]>.
+ */
+trait TaggedReferenceTrait
+{
+    public function hasTag(string $name): bool
+    {
+        return isset($this->tags[$name]);
+    }
+
+    /**
+     * @return string[]|null
+     */
+    public function getTagLines(string $name): ?array
+    {
+        return $this->tags[$name] ?? null;
+    }
+
+    public function getTagText(string $name): ?string
+    {
+        if ($this->hasTag($name)) {
+            return implode("\n", $this->getTagLines($name));
+        }
+
+        return null;
+    }
+}

--- a/src/Core/Ast/AstMap/TaggedReferenceTrait.php
+++ b/src/Core/Ast/AstMap/TaggedReferenceTrait.php
@@ -7,7 +7,7 @@ namespace Qossmic\Deptrac\Core\Ast\AstMap;
 /**
  * Helper trait for implementing TaggedTokenReferenceInterface.
  *
- * Classes that use this trait must define $this->tags as array<string,string[]>.
+ * Classes that use this trait must define $this->tags as array<string,list<string>>.
  *
  * @psalm-immutable
  */
@@ -19,7 +19,7 @@ trait TaggedReferenceTrait
     }
 
     /**
-     * @return string[]|null
+     * @return ?list<string>
      */
     public function getTagLines(string $name): ?array
     {

--- a/src/Core/Ast/AstMap/TaggedTokenReference.php
+++ b/src/Core/Ast/AstMap/TaggedTokenReference.php
@@ -4,15 +4,22 @@ declare(strict_types=1);
 
 namespace Qossmic\Deptrac\Core\Ast\AstMap;
 
+use Qossmic\Deptrac\Contract\Ast\TaggedTokenReferenceInterface;
+
 /**
  * Helper trait for implementing TaggedTokenReferenceInterface.
  *
- * Classes that use this trait must define $this->tags as array<string,list<string>>.
- *
  * @psalm-immutable
  */
-trait TaggedReferenceTrait
+abstract class TaggedTokenReference implements TaggedTokenReferenceInterface
 {
+    /**
+     * @param array<string,list<string>> $tags
+     */
+    protected function __construct(
+        private readonly array $tags
+    ) {}
+
     public function hasTag(string $name): bool
     {
         return isset($this->tags[$name]);

--- a/src/Core/Ast/Parser/NikicPhpParser/FileReferenceVisitor.php
+++ b/src/Core/Ast/Parser/NikicPhpParser/FileReferenceVisitor.php
@@ -167,8 +167,8 @@ class FileReferenceVisitor extends NodeVisitorAbstract
             $name = $node->name->toString();
         }
 
-        $tags = [];
         $docNodeCrate = $this->getDocNodeCrate($node);
+        $tags = [];
 
         if (null !== $docNodeCrate) {
             $tags = $this->extractTags($docNodeCrate[0]);

--- a/src/Core/Ast/Parser/NikicPhpParser/FileReferenceVisitor.php
+++ b/src/Core/Ast/Parser/NikicPhpParser/FileReferenceVisitor.php
@@ -113,7 +113,7 @@ class FileReferenceVisitor extends NodeVisitorAbstract
     /**
      * @return ?array{PhpDocNode, int} DocNode, comment start line
      */
-    private function getDocNodeCrate(ClassLike $node): ?array
+    private function getDocNodeCrate(Node $node): ?array
     {
         $docComment = $node->getDocComment();
         if (null === $docComment) {
@@ -129,21 +129,19 @@ class FileReferenceVisitor extends NodeVisitorAbstract
         $name = $this->getClassReferenceName($node);
         $docNodeCrate = $this->getDocNodeCrate($node);
         if (null !== $name) {
-            $isInternal = false;
+            $tags = [];
+
             if (null !== $docNodeCrate) {
-                $isInternal = [] !== array_merge(
-                    $docNodeCrate[0]->getTagsByName('@internal'),
-                    $docNodeCrate[0]->getTagsByName('@deptrac-internal')
-                );
+                $tags = $this->extractTags($docNodeCrate[0]);
             }
 
             match (true) {
-                $node instanceof Interface_ => $this->enterInterface($name, $node, $isInternal),
-                $node instanceof Class_ => $this->enterClass($name, $node, $isInternal),
+                $node instanceof Interface_ => $this->enterInterface($name, $node, $tags),
+                $node instanceof Class_ => $this->enterClass($name, $node, $tags),
                 $node instanceof Trait_ => $this->currentReference =
-                    $this->fileReferenceBuilder->newTrait($name, $this->templatesFromDocs($node), $isInternal),
+                    $this->fileReferenceBuilder->newTrait($name, $this->templatesFromDocs($node), $tags),
                 default => $this->currentReference =
-                    $this->fileReferenceBuilder->newClassLike($name, $this->templatesFromDocs($node), $isInternal)
+                    $this->fileReferenceBuilder->newClassLike($name, $this->templatesFromDocs($node), $tags)
             };
         }
 
@@ -169,7 +167,14 @@ class FileReferenceVisitor extends NodeVisitorAbstract
             $name = $node->name->toString();
         }
 
-        $this->currentReference = $this->fileReferenceBuilder->newFunction($name, $this->templatesFromDocs($node));
+        $tags = [];
+        $docNodeCrate = $this->getDocNodeCrate($node);
+
+        if (null !== $docNodeCrate) {
+            $tags = $this->extractTags($docNodeCrate[0]);
+        }
+
+        $this->currentReference = $this->fileReferenceBuilder->newFunction($name, $this->templatesFromDocs($node), $tags);
 
         foreach ($node->getParams() as $param) {
             if (null !== $param->type) {
@@ -208,18 +213,24 @@ class FileReferenceVisitor extends NodeVisitorAbstract
         return null;
     }
 
-    private function enterInterface(string $name, Interface_ $node, bool $isInternal): void
+    /**
+     * @param array<string,string[]> $tags
+     */
+    private function enterInterface(string $name, Interface_ $node, array $tags): void
     {
-        $this->currentReference = $this->fileReferenceBuilder->newInterface($name, $this->templatesFromDocs($node), $isInternal);
+        $this->currentReference = $this->fileReferenceBuilder->newInterface($name, $this->templatesFromDocs($node), $tags);
 
         foreach ($node->extends as $extend) {
             $this->currentReference->implements($extend->toCodeString(), $extend->getLine());
         }
     }
 
-    private function enterClass(string $name, Class_ $node, bool $isInternal): void
+    /**
+     * @param array<string,string[]> $tags
+     */
+    private function enterClass(string $name, Class_ $node, array $tags): void
     {
-        $this->currentReference = $this->fileReferenceBuilder->newClass($name, $this->templatesFromDocs($node), $isInternal);
+        $this->currentReference = $this->fileReferenceBuilder->newClass($name, $this->templatesFromDocs($node), $tags);
         if ($node->extends instanceof Name) {
             $this->currentReference->extends($node->extends->toCodeString(), $node->extends->getLine());
         }
@@ -297,5 +308,19 @@ class FileReferenceVisitor extends NodeVisitorAbstract
                 $this->currentReference->variable($type, $line);
             }
         }
+    }
+
+    /**
+     * @return array<string,string[]>
+     */
+    private function extractTags(PhpDocNode $doc): array
+    {
+        $tags = [];
+
+        foreach ($doc->getTags() as $tag) {
+            $tags[$tag->name][] = (string) $tag->value;
+        }
+
+        return $tags;
     }
 }

--- a/src/Core/Ast/Parser/NikicPhpParser/FileReferenceVisitor.php
+++ b/src/Core/Ast/Parser/NikicPhpParser/FileReferenceVisitor.php
@@ -214,7 +214,7 @@ class FileReferenceVisitor extends NodeVisitorAbstract
     }
 
     /**
-     * @param array<string,string[]> $tags
+     * @param array<string,list<string>> $tags
      */
     private function enterInterface(string $name, Interface_ $node, array $tags): void
     {
@@ -226,7 +226,7 @@ class FileReferenceVisitor extends NodeVisitorAbstract
     }
 
     /**
-     * @param array<string,string[]> $tags
+     * @param array<string,list<string>> $tags
      */
     private function enterClass(string $name, Class_ $node, array $tags): void
     {
@@ -311,7 +311,7 @@ class FileReferenceVisitor extends NodeVisitorAbstract
     }
 
     /**
-     * @return array<string,string[]>
+     * @return array<string,list<string>>
      */
     private function extractTags(PhpDocNode $doc): array
     {

--- a/src/Core/Layer/Collector/TagValueRegexCollector.php
+++ b/src/Core/Layer/Collector/TagValueRegexCollector.php
@@ -1,0 +1,68 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Qossmic\Deptrac\Core\Layer\Collector;
+
+use Qossmic\Deptrac\Contract\Ast\TaggedTokenReferenceInterface;
+use Qossmic\Deptrac\Contract\Ast\TokenReferenceInterface;
+use Qossmic\Deptrac\Contract\Layer\InvalidCollectorDefinitionException;
+
+final class TagValueRegexCollector extends RegexCollector
+{
+    /**
+     * @param array<string, bool|string|array<string, string>> $config
+     */
+    public function satisfy(array $config, TokenReferenceInterface $reference): bool
+    {
+        if (!$reference instanceof TaggedTokenReferenceInterface) {
+            return false;
+        }
+
+        $tagLines = $reference->getTagLines($this->getTagName($config));
+        $pattern = $this->getValidatedPattern($config);
+
+        if (null === $tagLines || [] === $tagLines) {
+            return false;
+        }
+
+        foreach ($tagLines as $line) {
+            if (preg_match($pattern, $line)) {
+                return true;
+            }
+        }
+
+        return false;
+    }
+
+    /**
+     * @param array<string, bool|string|array<string, string>|null> $config
+     *
+     * @throws InvalidCollectorDefinitionException
+     */
+    protected function getTagName(array $config): string
+    {
+        if (!isset($config['tag']) || !is_string($config['tag'])) {
+            throw InvalidCollectorDefinitionException::invalidCollectorConfiguration('TagValueRegexCollector needs the tag name.');
+        }
+
+        if (!preg_match('/^@[-\w]+$/', $config['tag'])) {
+            throw InvalidCollectorDefinitionException::invalidCollectorConfiguration('TagValueRegexCollector needs a valid tag name.');
+        }
+
+        return $config['tag'];
+    }
+
+    protected function getPattern(array $config): string
+    {
+        if (!isset($config['value'])) {
+            return '/^.?/'; // any string
+        }
+
+        if (!is_string($config['value'])) {
+            throw InvalidCollectorDefinitionException::invalidCollectorConfiguration('TagValueRegexCollector regex value must be a string.');
+        }
+
+        return $config['value'];
+    }
+}

--- a/src/Supportive/DependencyInjection/Configuration.php
+++ b/src/Supportive/DependencyInjection/Configuration.php
@@ -207,8 +207,10 @@ class Configuration implements ConfigurationInterface
                 ->arrayNode('analyser')
                     ->addDefaultsIfNotSet()
                     ->children()
+                        ->scalarNode('internal_tag')
+                            ->defaultNull()
+                            ->end()
                         ->arrayNode('types')
-                            ->isRequired()
                             ->defaultValue([
                                 EmitterType::CLASS_TOKEN->value,
                                 EmitterType::FUNCTION_TOKEN->value,

--- a/tests/Contract/Config/DeptracConfigTest.php
+++ b/tests/Contract/Config/DeptracConfigTest.php
@@ -5,7 +5,7 @@ declare(strict_types=1);
 namespace Tests\Qossmic\Deptrac\Contract\Analyser;
 
 use PHPUnit\Framework\TestCase;
-use Qossmic\Deptrac\Contract\Config\Analyser;
+use Qossmic\Deptrac\Contract\Config\AnalyserConfig;
 use Qossmic\Deptrac\Contract\Config\DeptracConfig;
 use Qossmic\Deptrac\Contract\Config\EmitterType;
 use Qossmic\Deptrac\Supportive\DependencyInjection\Configuration;
@@ -28,7 +28,7 @@ final class DeptracConfigTest extends TestCase
         $expected = [];
         yield 'empty' => [$config, $expected];
 
-        $config = (new DeptracConfig())->analyser(Analyser::create()->types(
+        $config = (new DeptracConfig())->analyser(AnalyserConfig::create()->types(
             EmitterType::FUNCTION_CALL
         ));
         $expected = [
@@ -39,7 +39,7 @@ final class DeptracConfigTest extends TestCase
         yield 'analyser types' => [$config, $expected];
 
         $config = (new DeptracConfig())->analyser(
-            Analyser::create()->internalTag('@layer-internal')
+            AnalyserConfig::create()->internalTag('@layer-internal')
         );
         $expected = [
             'analyser' => [

--- a/tests/Contract/Config/DeptracConfigTest.php
+++ b/tests/Contract/Config/DeptracConfigTest.php
@@ -1,0 +1,76 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Qossmic\Deptrac\Contract\Analyser;
+
+use PHPUnit\Framework\TestCase;
+use Qossmic\Deptrac\Contract\Config\Analyser;
+use Qossmic\Deptrac\Contract\Config\DeptracConfig;
+use Qossmic\Deptrac\Contract\Config\EmitterType;
+use Qossmic\Deptrac\Supportive\DependencyInjection\Configuration;
+use Symfony\Component\Config\Definition\Processor;
+
+final class DeptracConfigTest extends TestCase
+{
+    private function validateConfig(array $config)
+    {
+        $processor = new Processor();
+        $def = new Configuration();
+
+        $processor->process($def->getConfigTreeBuilder()->buildTree(), ['deptrac' => $config]);
+        $this->addToAssertionCount(1);
+    }
+
+    public static function provideConfig()
+    {
+        $config = new DeptracConfig();
+        $expected = [];
+        yield 'empty' => [$config, $expected];
+
+        $config = (new DeptracConfig())->analyser(Analyser::create()->types(
+            EmitterType::FUNCTION_CALL
+        ));
+        $expected = [
+            'analyser' => [
+                'types' => [EmitterType::FUNCTION_CALL->value => EmitterType::FUNCTION_CALL->value],
+            ],
+        ];
+        yield 'analyser types' => [$config, $expected];
+
+        $config = (new DeptracConfig())->analyser(
+            Analyser::create()->internalTag('@layer-internal')
+        );
+        $expected = [
+            'analyser' => [
+                'internal_tag' => '@layer-internal',
+            ],
+        ];
+        yield 'internal_tag' => [$config, $expected];
+    }
+
+    /**
+     * @dataProvider provideConfig
+     */
+    public function testConfigCompliance(DeptracConfig $config, array $expected): void
+    {
+        $array = $config->toArray();
+        $this->validateConfig($array);
+        $this->assertArrayContainsRecursive($expected, $array);
+    }
+
+    private function assertArrayContainsRecursive(array $expected, array $actual)
+    {
+        foreach ($expected as $key => $value) {
+            self::assertArrayHasKey($key, $actual);
+
+            if (is_array($value)) {
+                $this->assertIsArray($actual[$key], $key);
+
+                $this->assertArrayContainsRecursive($value, $actual[$key]);
+            } else {
+                $this->assertSame($value, $actual[$key], $key);
+            }
+        }
+    }
+}

--- a/tests/Core/Analyser/EventHandler/DependsOnInternalTokenTest.php
+++ b/tests/Core/Analyser/EventHandler/DependsOnInternalTokenTest.php
@@ -53,41 +53,41 @@ class DependsOnInternalTokenTest extends TestCase
         return $event;
     }
 
-    public function testInvokeEnabled(): void
+    public function testInvoke(): void
     {
         $helper = new EventHelper([], new LayerProvider([]));
-        $handler = new DependsOnInternalToken($helper);
+        $handler = new DependsOnInternalToken($helper, ['internal_tag' => '@layer-internal']);
 
         $event = $this->makeEvent([], []);
         $handler->invoke($event);
 
         $this->assertFalse(
             $event->isPropagationStopped(),
-            'Propagation should continue if neither reference has the "internal" tag'
+            'Propagation should continue if neither reference has the "layer-internal" tag'
         );
 
-        $event = $this->makeEvent(['@internal' => ['']], []);
+        $event = $this->makeEvent(['@layer-internal' => ['']], []);
         $handler->invoke($event);
 
         $this->assertFalse(
             $event->isPropagationStopped(),
-            'Propagation should continue if only the depender is marked @internal'
+            'Propagation should continue if only the depender is marked @layer-internal'
         );
 
-        $event = $this->makeEvent([], ['@internal' => ['']]);
+        $event = $this->makeEvent([], ['@layer-internal' => ['']]);
         $handler->invoke($event);
 
         $this->assertTrue(
             $event->isPropagationStopped(),
-            'Propagation should be stopped if the dependent is marked @internal'
+            'Propagation should be stopped if the dependent is marked @layer-internal'
         );
 
-        $event = $this->makeEvent([], ['@internal' => ['']], 'DependerLayer');
+        $event = $this->makeEvent([], ['@layer-internal' => ['']], 'DependerLayer');
         $handler->invoke($event);
 
         $this->assertFalse(
             $event->isPropagationStopped(),
-            'Propagation should not be stopped if the dependent is marked @internal '.
+            'Propagation should not be stopped if the dependent is marked @layer-internal '.
             'but dependent is in the same layer'
         );
 
@@ -97,6 +97,28 @@ class DependsOnInternalTokenTest extends TestCase
         $this->assertTrue(
             $event->isPropagationStopped(),
             'Propagation should be stopped if the dependent is marked @deptrac-internal'
+        );
+    }
+
+    public function testDefaultInternalTag(): void
+    {
+        $helper = new EventHelper([], new LayerProvider([]));
+        $handler = new DependsOnInternalToken($helper, ['internal_tag' => null]);
+
+        $event = $this->makeEvent([], ['@internal' => ['']]);
+        $handler->invoke($event);
+
+        $this->assertFalse(
+            $event->isPropagationStopped(),
+            'The @internal tag should not be used per default'
+        );
+
+        $event = $this->makeEvent([], ['@deptrac-internal' => ['']]);
+        $handler->invoke($event);
+
+        $this->assertTrue(
+            $event->isPropagationStopped(),
+            'The @deptrac-internal tag should be used per default'
         );
     }
 }

--- a/tests/Core/Analyser/EventHandler/DependsOnInternalTokenTest.php
+++ b/tests/Core/Analyser/EventHandler/DependsOnInternalTokenTest.php
@@ -1,0 +1,102 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Qossmic\Deptrac\Core\Analyser\EventHandler;
+
+use PHPUnit\Framework\TestCase;
+use Qossmic\Deptrac\Contract\Analyser\AnalysisResult;
+use Qossmic\Deptrac\Contract\Analyser\EventHelper;
+use Qossmic\Deptrac\Contract\Analyser\ProcessEvent;
+use Qossmic\Deptrac\Contract\Ast\DependencyType;
+use Qossmic\Deptrac\Contract\Ast\FileOccurrence;
+use Qossmic\Deptrac\Contract\Layer\LayerProvider;
+use Qossmic\Deptrac\Core\Analyser\EventHandler\DependsOnInternalToken;
+use Qossmic\Deptrac\Core\Ast\AstMap\ClassLike\ClassLikeReference;
+use Qossmic\Deptrac\Core\Ast\AstMap\ClassLike\ClassLikeToken;
+use Qossmic\Deptrac\Core\Ast\AstMap\ClassLike\ClassLikeType;
+use Qossmic\Deptrac\Core\Dependency\Dependency;
+
+class DependsOnInternalTokenTest extends TestCase
+{
+    public function testGetSubscribedEvents(): void
+    {
+        $subscribedEvents = DependsOnInternalToken::getSubscribedEvents();
+
+        self::assertCount(1, $subscribedEvents);
+        self::assertArrayHasKey(ProcessEvent::class, $subscribedEvents);
+        self::assertSame(['invoke', -2], $subscribedEvents[ProcessEvent::class]);
+    }
+
+    private function makeEvent(
+        array $dependerTags, array $dependentTags, $dependentLayer = 'DependentLayer'
+    ): ProcessEvent {
+        $dependerToken = ClassLikeToken::fromFQCN('DependerClass');
+        $dependentToken = ClassLikeToken::fromFQCN('DependentClass');
+
+        $event = new ProcessEvent(
+            new Dependency(
+                $dependerToken,
+                $dependentToken,
+                new FileOccurrence('test', 1),
+                DependencyType::STATIC_METHOD
+            ),
+            new ClassLikeReference($dependerToken, ClassLikeType::TYPE_CLASS,
+                [], [], $dependerTags),
+            'DependerLayer',
+            new ClassLikeReference($dependentToken, ClassLikeType::TYPE_CLASS,
+                [], [], $dependentTags),
+            [$dependentLayer => true],
+            new AnalysisResult()
+        );
+
+        return $event;
+    }
+
+    public function testInvokeEnabled(): void
+    {
+        $helper = new EventHelper([], new LayerProvider([]));
+        $handler = new DependsOnInternalToken($helper);
+
+        $event = $this->makeEvent([], []);
+        $handler->invoke($event);
+
+        $this->assertFalse(
+            $event->isPropagationStopped(),
+            'Propagation should continue if neither reference has the "internal" tag'
+        );
+
+        $event = $this->makeEvent(['@internal' => ['']], []);
+        $handler->invoke($event);
+
+        $this->assertFalse(
+            $event->isPropagationStopped(),
+            'Propagation should continue if only the depender is marked @internal'
+        );
+
+        $event = $this->makeEvent([], ['@internal' => ['']]);
+        $handler->invoke($event);
+
+        $this->assertTrue(
+            $event->isPropagationStopped(),
+            'Propagation should be stopped if the dependent is marked @internal'
+        );
+
+        $event = $this->makeEvent([], ['@internal' => ['']], 'DependerLayer');
+        $handler->invoke($event);
+
+        $this->assertFalse(
+            $event->isPropagationStopped(),
+            'Propagation should not be stopped if the dependent is marked @internal '.
+            'but dependent is in the same layer'
+        );
+
+        $event = $this->makeEvent([], ['@deptrac-internal' => ['']]);
+        $handler->invoke($event);
+
+        $this->assertTrue(
+            $event->isPropagationStopped(),
+            'Propagation should be stopped if the dependent is marked @deptrac-internal'
+        );
+    }
+}

--- a/tests/Core/Ast/AstMap/ClassLike/ClassLikeReferenceTest.php
+++ b/tests/Core/Ast/AstMap/ClassLike/ClassLikeReferenceTest.php
@@ -1,0 +1,28 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Qossmic\Deptrac\Core\Ast\AstMap\ClassLike;
+
+use PHPUnit\Framework\TestCase;
+use Qossmic\Deptrac\Contract\Ast\TaggedTokenReferenceInterface;
+use Qossmic\Deptrac\Core\Ast\AstMap\ClassLike\ClassLikeReference;
+use Qossmic\Deptrac\Core\Ast\AstMap\ClassLike\ClassLikeToken;
+use Qossmic\Deptrac\Core\Ast\AstMap\ClassLike\ClassLikeType;
+use Tests\Qossmic\Deptrac\Core\Ast\AstMap\TaggedTokenReferenceTestTrait;
+
+final class ClassLikeReferenceTest extends TestCase
+{
+    use TaggedTokenReferenceTestTrait;
+
+    private function newWithTags(array $tags): TaggedTokenReferenceInterface
+    {
+        return new ClassLikeReference(
+            ClassLikeToken::fromFQCN('Test'),
+            ClassLikeType::TYPE_CLASS,
+            [],
+            [],
+            $tags
+        );
+    }
+}

--- a/tests/Core/Ast/AstMap/Function/FunctionReferenceTest.php
+++ b/tests/Core/Ast/AstMap/Function/FunctionReferenceTest.php
@@ -1,0 +1,25 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Qossmic\Deptrac\Core\Ast\AstMap\Function;
+
+use PHPUnit\Framework\TestCase;
+use Qossmic\Deptrac\Contract\Ast\TaggedTokenReferenceInterface;
+use Qossmic\Deptrac\Core\Ast\AstMap\Function\FunctionReference;
+use Qossmic\Deptrac\Core\Ast\AstMap\Function\FunctionToken;
+use Tests\Qossmic\Deptrac\Core\Ast\AstMap\TaggedTokenReferenceTestTrait;
+
+final class FunctionReferenceTest extends TestCase
+{
+    use TaggedTokenReferenceTestTrait;
+
+    private function newWithTags(array $tags): TaggedTokenReferenceInterface
+    {
+        return new FunctionReference(
+            FunctionToken::fromFQCN('testing'),
+            [],
+            $tags
+        );
+    }
+}

--- a/tests/Core/Ast/AstMap/TaggedTokenReferenceTestTrait.php
+++ b/tests/Core/Ast/AstMap/TaggedTokenReferenceTestTrait.php
@@ -1,0 +1,37 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Qossmic\Deptrac\Core\Ast\AstMap;
+
+use Qossmic\Deptrac\Contract\Ast\TaggedTokenReferenceInterface;
+
+trait TaggedTokenReferenceTestTrait
+{
+    abstract private function newWithTags(array $tags): TaggedTokenReferenceInterface;
+
+    public function testTags(): void
+    {
+        $tags = [
+            '@foo' => ['foo1'],
+            '@bar' => ['bar1', 'bar2'],
+        ];
+
+        $ref = $this->newWithTags($tags);
+
+        self::assertTrue($ref->hasTag('@foo'), 'has @foo');
+        self::assertTrue($ref->hasTag('@bar'), 'has @bar');
+        self::assertFalse($ref->hasTag('foo'), 'has foo');
+        self::assertFalse($ref->hasTag('@xyzzy'), 'has @xyzzy');
+
+        self::assertSame(['foo1'], $ref->getTagLines('@foo'), 'get @foo lines');
+        self::assertSame(['bar1', 'bar2'], $ref->getTagLines('@bar'), 'get @bar lines');
+        self::assertnull($ref->getTagLines('foo'), 'get foo lines');
+        self::assertnull($ref->getTagLines('@xyzzy'), 'get @xyzzy lines');
+
+        self::assertSame('foo1', $ref->getTagText('@foo'), 'get @foo text');
+        self::assertSame("bar1\nbar2", $ref->getTagText('@bar'), 'get @bar text');
+        self::assertnull($ref->getTagText('foo'), 'get foo text');
+        self::assertnull($ref->getTagText('@xyzzy'), 'get @xyzzy text');
+    }
+}

--- a/tests/Core/Ast/AstMap/TaggedTokenReferenceTestTrait.php
+++ b/tests/Core/Ast/AstMap/TaggedTokenReferenceTestTrait.php
@@ -28,10 +28,5 @@ trait TaggedTokenReferenceTestTrait
         self::assertSame(['bar1', 'bar2'], $ref->getTagLines('@bar'), 'get @bar lines');
         self::assertnull($ref->getTagLines('foo'), 'get foo lines');
         self::assertnull($ref->getTagLines('@xyzzy'), 'get @xyzzy lines');
-
-        self::assertSame('foo1', $ref->getTagText('@foo'), 'get @foo text');
-        self::assertSame("bar1\nbar2", $ref->getTagText('@bar'), 'get @bar text');
-        self::assertnull($ref->getTagText('foo'), 'get foo text');
-        self::assertnull($ref->getTagText('@xyzzy'), 'get @xyzzy text');
     }
 }

--- a/tests/Core/Ast/Parser/NikicPhpParser/Fixtures/DocTags.php
+++ b/tests/Core/Ast/Parser/NikicPhpParser/Fixtures/DocTags.php
@@ -1,0 +1,19 @@
+<?php
+
+declare(strict_types = 1);
+
+namespace Tests\Qossmic\Deptrac\Core\Ast\Parser\NikicPhpParser\Fixtures;
+
+class UntaggedThing
+{
+    public function untaggedFunction() {}
+}
+
+/**
+ * @internal
+ * @note Note one
+ * @note Note two
+ */
+class TaggedThing
+{
+}

--- a/tests/Core/Ast/Parser/NikicPhpParser/Fixtures/Functions.php
+++ b/tests/Core/Ast/Parser/NikicPhpParser/Fixtures/Functions.php
@@ -1,0 +1,15 @@
+<?php
+
+declare(strict_types = 1);
+
+namespace Tests\Qossmic\Deptrac\Core\Ast\Parser\NikicPhpParser\Fixtures {
+
+    function untaggedFunction() {}
+
+    /**
+     * @param string $foo
+     * @param string $bar
+     */
+    function taggedFunction(string $foo, string $bar) {}
+
+}

--- a/tests/Core/Ast/Parser/NikicPhpParser/NikicPhpParserTest.php
+++ b/tests/Core/Ast/Parser/NikicPhpParser/NikicPhpParserTest.php
@@ -125,7 +125,7 @@ final class NikicPhpParserTest extends TestCase
     {
         $typeResolver = new TypeResolver();
         $parser = new NikicPhpParser(
-            ( new ParserFactory() )->create(
+            (new ParserFactory())->create(
                 ParserFactory::ONLY_PHP7,
                 new Lexer()
             ),

--- a/tests/Core/Layer/Collector/AttributeCollectorTest.php
+++ b/tests/Core/Layer/Collector/AttributeCollectorTest.php
@@ -41,7 +41,7 @@ final class AttributeCollectorTest extends TestCase
     public function testSatisfy(array $config, bool $expected): void
     {
         $classLikeReference = FileReferenceBuilder::create('Foo.php')
-            ->newClass('App\Foo', [], false)
+            ->newClass('App\Foo', [], [])
             ->attribute('App\MyAttribute', 2)
             ->attribute('MyAttribute', 3)
             ->build();

--- a/tests/Core/Layer/Collector/DirectoryCollectorTest.php
+++ b/tests/Core/Layer/Collector/DirectoryCollectorTest.php
@@ -34,7 +34,7 @@ final class DirectoryCollectorTest extends TestCase
     public function testSatisfy(array $configuration, string $filePath, bool $expected): void
     {
         $fileReferenceBuilder = FileReferenceBuilder::create($filePath);
-        $fileReferenceBuilder->newClassLike('Test', [], false);
+        $fileReferenceBuilder->newClassLike('Test', [], []);
         $fileReference = $fileReferenceBuilder->build();
 
         $actual = $this->collector->satisfy(
@@ -48,7 +48,7 @@ final class DirectoryCollectorTest extends TestCase
     public function testMissingRegexThrowsException(): void
     {
         $fileReferenceBuilder = FileReferenceBuilder::create('/some/path/to/file.php');
-        $fileReferenceBuilder->newClassLike('Test', [], false);
+        $fileReferenceBuilder->newClassLike('Test', [], []);
         $fileReference = $fileReferenceBuilder->build();
 
         $this->expectException(InvalidCollectorDefinitionException::class);
@@ -63,7 +63,7 @@ final class DirectoryCollectorTest extends TestCase
     public function testInvalidRegexParam(): void
     {
         $fileReferenceBuilder = FileReferenceBuilder::create('/some/path/to/file.php');
-        $fileReferenceBuilder->newClassLike('Test', [], false);
+        $fileReferenceBuilder->newClassLike('Test', [], []);
         $fileReference = $fileReferenceBuilder->build();
 
         $this->expectException(InvalidCollectorDefinitionException::class);

--- a/tests/Core/Layer/Collector/ExtendsCollectorTest.php
+++ b/tests/Core/Layer/Collector/ExtendsCollectorTest.php
@@ -28,28 +28,28 @@ final class ExtendsCollectorTest extends TestCase
     {
         $fooFileReferenceBuilder = FileReferenceBuilder::create('foo.php');
         $fooFileReferenceBuilder
-            ->newClassLike('App\Foo', [], false)
+            ->newClassLike('App\Foo', [], [])
             ->implements('App\Bar', 2);
         $fooFileReference = $fooFileReferenceBuilder->build();
 
         $barFileReferenceBuilder = FileReferenceBuilder::create('bar.php');
         $barFileReferenceBuilder
-            ->newClassLike('App\Bar', [], false)
+            ->newClassLike('App\Bar', [], [])
             ->implements('App\Baz', 2);
         $barFileReference = $barFileReferenceBuilder->build();
 
         $bazFileReferenceBuilder = FileReferenceBuilder::create('baz.php');
-        $bazFileReferenceBuilder->newClassLike('App\Baz', [], false);
+        $bazFileReferenceBuilder->newClassLike('App\Baz', [], []);
         $bazFileReference = $bazFileReferenceBuilder->build();
 
         $fizTraitFileReferenceBuilder = FileReferenceBuilder::create('fiztrait.php');
         $fizTraitFileReferenceBuilder
-            ->newClassLike('App\FizTrait', [], false);
+            ->newClassLike('App\FizTrait', [], []);
         $fizTraitFileReference = $fizTraitFileReferenceBuilder->build();
 
         $fooBarFileReferenceBuilder = FileReferenceBuilder::create('foobar.php');
         $fooBarFileReferenceBuilder
-            ->newClassLike('App\FooBar', [], false)
+            ->newClassLike('App\FooBar', [], [])
             ->extends('App\Foo', 2)
             ->trait('App\FizTrait', 4);
         $fooBarFileReference = $fooBarFileReferenceBuilder->build();

--- a/tests/Core/Layer/Collector/GlobCollectorTest.php
+++ b/tests/Core/Layer/Collector/GlobCollectorTest.php
@@ -34,7 +34,7 @@ final class GlobCollectorTest extends TestCase
     public function testSatisfy(array $configuration, string $filePath, bool $expected): void
     {
         $fileReferenceBuilder = FileReferenceBuilder::create($filePath);
-        $fileReferenceBuilder->newClassLike('Test', [], false);
+        $fileReferenceBuilder->newClassLike('Test', [], []);
         $fileReference = $fileReferenceBuilder->build();
 
         $actual = $this->collector->satisfy(

--- a/tests/Core/Layer/Collector/ImplementsCollectorTest.php
+++ b/tests/Core/Layer/Collector/ImplementsCollectorTest.php
@@ -28,28 +28,28 @@ final class ImplementsCollectorTest extends TestCase
     {
         $fooFileReferenceBuilder = FileReferenceBuilder::create('foo.php');
         $fooFileReferenceBuilder
-            ->newClassLike('App\Foo', [], false)
+            ->newClassLike('App\Foo', [], [])
             ->implements('App\Bar', 2);
         $fooFileReference = $fooFileReferenceBuilder->build();
 
         $barFileReferenceBuilder = FileReferenceBuilder::create('bar.php');
         $barFileReferenceBuilder
-            ->newClassLike('App\Bar', [], false)
+            ->newClassLike('App\Bar', [], [])
             ->implements('App\Baz', 2);
         $barFileReference = $barFileReferenceBuilder->build();
 
         $bazFileReferenceBuilder = FileReferenceBuilder::create('baz.php');
-        $bazFileReferenceBuilder->newClassLike('App\Baz', [], false);
+        $bazFileReferenceBuilder->newClassLike('App\Baz', [], []);
         $bazFileReference = $bazFileReferenceBuilder->build();
 
         $fizTraitFileReferenceBuilder = FileReferenceBuilder::create('fiztrait.php');
         $fizTraitFileReferenceBuilder
-            ->newClassLike('App\FizTrait', [], false);
+            ->newClassLike('App\FizTrait', [], []);
         $fizTraitFileReference = $fizTraitFileReferenceBuilder->build();
 
         $fooBarFileReferenceBuilder = FileReferenceBuilder::create('foobar.php');
         $fooBarFileReferenceBuilder
-            ->newClassLike('App\FooBar', [], false)
+            ->newClassLike('App\FooBar', [], [])
             ->extends('App\Foo', 2)
             ->trait('App\FizTrait', 4);
         $fooBarFileReference = $fooBarFileReferenceBuilder->build();

--- a/tests/Core/Layer/Collector/InheritsCollectorTest.php
+++ b/tests/Core/Layer/Collector/InheritsCollectorTest.php
@@ -28,28 +28,28 @@ final class InheritsCollectorTest extends TestCase
     {
         $fooFileReferenceBuilder = FileReferenceBuilder::create('foo.php');
         $fooFileReferenceBuilder
-            ->newClassLike('App\Foo', [], false)
+            ->newClassLike('App\Foo', [], [])
             ->implements('App\Bar', 2);
         $fooFileReference = $fooFileReferenceBuilder->build();
 
         $barFileReferenceBuilder = FileReferenceBuilder::create('bar.php');
         $barFileReferenceBuilder
-            ->newClassLike('App\Bar', [], false)
+            ->newClassLike('App\Bar', [], [])
             ->implements('App\Baz', 2);
         $barFileReference = $barFileReferenceBuilder->build();
 
         $bazFileReferenceBuilder = FileReferenceBuilder::create('baz.php');
-        $bazFileReferenceBuilder->newClassLike('App\Baz', [], false);
+        $bazFileReferenceBuilder->newClassLike('App\Baz', [], []);
         $bazFileReference = $bazFileReferenceBuilder->build();
 
         $fizTraitFileReferenceBuilder = FileReferenceBuilder::create('fiztrait.php');
         $fizTraitFileReferenceBuilder
-            ->newClassLike('App\FizTrait', [], false);
+            ->newClassLike('App\FizTrait', [], []);
         $fizTraitFileReference = $fizTraitFileReferenceBuilder->build();
 
         $fooBarFileReferenceBuilder = FileReferenceBuilder::create('foobar.php');
         $fooBarFileReferenceBuilder
-            ->newClassLike('App\FooBar', [], false)
+            ->newClassLike('App\FooBar', [], [])
             ->extends('App\Foo', 2)
             ->trait('App\FizTrait', 4);
         $fooBarFileReference = $fooBarFileReferenceBuilder->build();

--- a/tests/Core/Layer/Collector/TagValueRegexCollectorTest.php
+++ b/tests/Core/Layer/Collector/TagValueRegexCollectorTest.php
@@ -1,0 +1,114 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Qossmic\Deptrac\Core\Layer\Collector;
+
+use PHPUnit\Framework\TestCase;
+use Qossmic\Deptrac\Contract\Config\Collector\TagValueRegexConfig;
+use Qossmic\Deptrac\Contract\Layer\InvalidCollectorDefinitionException;
+use Qossmic\Deptrac\Core\Ast\AstMap\ClassLike\ClassLikeReference;
+use Qossmic\Deptrac\Core\Ast\AstMap\ClassLike\ClassLikeToken;
+use Qossmic\Deptrac\Core\Ast\AstMap\ClassLike\ClassLikeType;
+use Qossmic\Deptrac\Core\Layer\Collector\TagValueRegexCollector;
+
+final class TagValueRegexCollectorTest extends TestCase
+{
+    private TagValueRegexCollector $collector;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        $this->collector = new TagValueRegexCollector();
+    }
+
+    public static function dataProviderSatisfy(): iterable
+    {
+        yield [TagValueRegexConfig::create('@foo'), ['@foo' => ['']]];
+
+        yield [TagValueRegexConfig::create('@foo'), ['@foo' => ['anything']]];
+
+        yield [
+            TagValueRegexConfig::create('@foo-bar', '/some/'),
+            ['@xyz' => [''], '@foo-bar' => ['anything', 'something']],
+        ];
+
+        yield [
+            TagValueRegexConfig::create('@foo-bar')->match('!thing$!'),
+            ['@xyz' => [''], '@foo-bar' => ['anything', 'something']],
+        ];
+    }
+
+    /**
+     * @dataProvider dataProviderSatisfy
+     */
+    public function testSatisfy(TagValueRegexConfig $configuration, array $tags): void
+    {
+        $actual = $this->collector->satisfy(
+            $configuration->toArray(),
+            new ClassLikeReference(ClassLikeToken::fromFQCN('Dummy'), ClassLikeType::TYPE_CLASS, [], [], $tags)
+        );
+
+        self::assertTrue($actual);
+    }
+
+    public static function dataProviderNotSatisfy(): iterable
+    {
+        yield [TagValueRegexConfig::create('@foo'), ['@bar' => ['anything']]];
+
+        yield [
+            TagValueRegexConfig::create('@foo', '/something/'),
+            ['@xyz' => [''], '@foo' => ['anything', 'another thing']],
+        ];
+        yield [
+            TagValueRegexConfig::create('@foo', '/^thing/'),
+            ['@xyz' => [''], '@foo' => ['anything', 'another thing']],
+        ];
+    }
+
+    /**
+     * @dataProvider dataProviderNotSatisfy
+     */
+    public function testNotSatisfy(TagValueRegexConfig $configuration, array $tags): void
+    {
+        $actual = $this->collector->satisfy(
+            $configuration->toArray(),
+            new ClassLikeReference(ClassLikeToken::fromFQCN('Dummy'), ClassLikeType::TYPE_CLASS, [], [], $tags)
+        );
+
+        self::assertFalse($actual);
+    }
+
+    public static function dataProviderBadConfig(): iterable
+    {
+        yield 'empty' => [[]];
+
+        yield 'no tag name' => [['value' => '/.+/']];
+
+        yield 'empty tag name' => [['tag' => '']];
+
+        yield 'tag name with missing ampersand' => [['tag' => 'foo']];
+
+        yield 'tag name with space' => [['tag' => '@foo bar']];
+
+        yield 'non-string tag name' => [['tag' => 1234]];
+
+        yield 'non-string regex value' => [['tag' => '@test', 'value' => 1234]];
+
+        yield 'bad regex value' => [['tag' => '@test', 'value' => '(((]]]']];
+    }
+
+    /**
+     * @dataProvider dataProviderBadConfig
+     */
+    public function testBadConfig($config): void
+    {
+        $this->expectException(InvalidCollectorDefinitionException::class);
+
+        $this->collector->satisfy(
+            $config,
+            new ClassLikeReference(ClassLikeToken::fromFQCN('Foo'))
+        );
+    }
+}

--- a/tests/Core/Layer/Collector/UsesCollectorTest.php
+++ b/tests/Core/Layer/Collector/UsesCollectorTest.php
@@ -28,28 +28,28 @@ final class UsesCollectorTest extends TestCase
     {
         $fooFileReferenceBuilder = FileReferenceBuilder::create('foo.php');
         $fooFileReferenceBuilder
-            ->newClassLike('App\Foo', [], false)
+            ->newClassLike('App\Foo', [], [])
             ->implements('App\Bar', 2);
         $fooFileReference = $fooFileReferenceBuilder->build();
 
         $barFileReferenceBuilder = FileReferenceBuilder::create('bar.php');
         $barFileReferenceBuilder
-            ->newClassLike('App\Bar', [], false)
+            ->newClassLike('App\Bar', [], [])
             ->implements('App\Baz', 2);
         $barFileReference = $barFileReferenceBuilder->build();
 
         $bazFileReferenceBuilder = FileReferenceBuilder::create('baz.php');
-        $bazFileReferenceBuilder->newClassLike('App\Baz', [], false);
+        $bazFileReferenceBuilder->newClassLike('App\Baz', [], []);
         $bazFileReference = $bazFileReferenceBuilder->build();
 
         $fizTraitFileReferenceBuilder = FileReferenceBuilder::create('fiztrait.php');
         $fizTraitFileReferenceBuilder
-            ->newClassLike('App\FizTrait', [], false);
+            ->newClassLike('App\FizTrait', [], []);
         $fizTraitFileReference = $fizTraitFileReferenceBuilder->build();
 
         $fooBarFileReferenceBuilder = FileReferenceBuilder::create('foobar.php');
         $fooBarFileReferenceBuilder
-            ->newClassLike('App\FooBar', [], false)
+            ->newClassLike('App\FooBar', [], [])
             ->extends('App\Foo', 2)
             ->trait('App\FizTrait', 4);
         $fooBarFileReference = $fooBarFileReferenceBuilder->build();

--- a/tests/Supportive/DependencyInjection/DeptracExtensionTest.php
+++ b/tests/Supportive/DependencyInjection/DeptracExtensionTest.php
@@ -17,7 +17,8 @@ final class DeptracExtensionTest extends TestCase
 {
     private ContainerBuilder $container;
     private DeptracExtension $extension;
-    private array $formatterDefaults = [
+
+    private const FORMATTER_DEFAULTS = [
         'graphviz' => [
             'hidden_layers' => [],
             'groups' => [],
@@ -29,6 +30,14 @@ final class DeptracExtensionTest extends TestCase
                 'skipped' => 'minor',
                 'uncovered' => 'info',
             ],
+        ],
+    ];
+
+    private const ANALYSER_DEFAULTS = [
+        'internal_tag' => null,
+        'types' => [
+            'class',
+            'function',
         ],
     ];
 
@@ -51,8 +60,8 @@ final class DeptracExtensionTest extends TestCase
         self::assertSame([], $this->container->getParameter('layers'));
         self::assertSame([], $this->container->getParameter('ruleset'));
         self::assertSame([], $this->container->getParameter('skip_violations'));
-        self::assertSame($this->formatterDefaults, $this->container->getParameter('formatters'));
-        self::assertSame(['types' => [EmitterType::CLASS_TOKEN->value, EmitterType::FUNCTION_TOKEN->value]], $this->container->getParameter('analyser'));
+        self::assertSame(self::FORMATTER_DEFAULTS, $this->container->getParameter('formatters'));
+        self::assertSame(self::ANALYSER_DEFAULTS, $this->container->getParameter('analyser'));
         self::assertSame(true, $this->container->getParameter('ignore_uncovered_internal_classes'));
     }
 
@@ -69,8 +78,8 @@ final class DeptracExtensionTest extends TestCase
         self::assertSame([], $this->container->getParameter('layers'));
         self::assertSame([], $this->container->getParameter('ruleset'));
         self::assertSame([], $this->container->getParameter('skip_violations'));
-        self::assertSame($this->formatterDefaults, $this->container->getParameter('formatters'));
-        self::assertSame(['types' => [EmitterType::CLASS_TOKEN->value, EmitterType::FUNCTION_TOKEN->value]], $this->container->getParameter('analyser'));
+        self::assertSame(self::FORMATTER_DEFAULTS, $this->container->getParameter('formatters'));
+        self::assertSame(self::ANALYSER_DEFAULTS, $this->container->getParameter('analyser'));
         self::assertSame(true, $this->container->getParameter('ignore_uncovered_internal_classes'));
     }
 
@@ -307,10 +316,12 @@ final class DeptracExtensionTest extends TestCase
             ],
         ];
 
-        $this->expectException(InvalidConfigurationException::class);
-        $this->expectExceptionMessage('The child config "types" under "deptrac.analyser" must be configured.');
-
         $this->extension->load($configs, $this->container);
+
+        self::assertSame(
+            self::ANALYSER_DEFAULTS,
+            $this->container->getParameter('analyser')
+        );
     }
 
     public function testEmptyAnalyser(): void
@@ -321,10 +332,12 @@ final class DeptracExtensionTest extends TestCase
             ],
         ];
 
-        $this->expectException(InvalidConfigurationException::class);
-        $this->expectExceptionMessage('The child config "types" under "deptrac.analyser" must be configured.');
-
         $this->extension->load($configs, $this->container);
+
+        self::assertSame(
+            self::ANALYSER_DEFAULTS,
+            $this->container->getParameter('analyser')
+        );
     }
 
     public function testInvalidAnalyserTypes(): void
@@ -333,7 +346,7 @@ final class DeptracExtensionTest extends TestCase
             'deptrac' => [
                 'analyser' => [
                     'types' => ['invalid'],
-                ],
+                ] + self::ANALYSER_DEFAULTS,
             ],
         ];
 
@@ -349,14 +362,14 @@ final class DeptracExtensionTest extends TestCase
             'deptrac' => [
                 'analyser' => [
                     'types' => null,
-                ],
+                ] + self::ANALYSER_DEFAULTS,
             ],
         ];
 
         $this->extension->load($configs, $this->container);
 
         self::assertSame(
-            ['types' => []],
+            ['types' => []] + self::ANALYSER_DEFAULTS,
             $this->container->getParameter('analyser')
         );
     }
@@ -367,14 +380,14 @@ final class DeptracExtensionTest extends TestCase
             'deptrac' => [
                 'analyser' => [
                     'types' => [],
-                ],
+                ] + self::ANALYSER_DEFAULTS,
             ],
         ];
 
         $this->extension->load($configs, $this->container);
 
         self::assertSame(
-            ['types' => []],
+            ['types' => []] + self::ANALYSER_DEFAULTS,
             $this->container->getParameter('analyser')
         );
     }
@@ -385,14 +398,15 @@ final class DeptracExtensionTest extends TestCase
             'deptrac' => [
                 'analyser' => [
                     'types' => [EmitterType::CLASS_TOKEN->value, EmitterType::CLASS_TOKEN->value],
-                ],
+                ] + self::ANALYSER_DEFAULTS,
             ],
         ];
 
         $this->extension->load($configs, $this->container);
 
         self::assertSame(
-            ['types' => [EmitterType::CLASS_TOKEN->value, EmitterType::CLASS_TOKEN->value]],
+            ['types' => [EmitterType::CLASS_TOKEN->value, EmitterType::CLASS_TOKEN->value]]
+                + self::ANALYSER_DEFAULTS,
             $this->container->getParameter('analyser')
         );
     }
@@ -422,7 +436,7 @@ final class DeptracExtensionTest extends TestCase
 
         $this->extension->load($configs, $this->container);
 
-        $expectedFormatterConfig = $this->formatterDefaults;
+        $expectedFormatterConfig = self::FORMATTER_DEFAULTS;
         $actualFormatterConfig = $this->container->getParameter('formatters');
 
         krsort($expectedFormatterConfig);
@@ -445,7 +459,7 @@ final class DeptracExtensionTest extends TestCase
 
         $this->extension->load($configs, $this->container);
 
-        $expectedFormatterConfig = $this->formatterDefaults;
+        $expectedFormatterConfig = self::FORMATTER_DEFAULTS;
         $expectedFormatterConfig['graphviz'] = [
             'point_to_groups' => true,
             'hidden_layers' => [],
@@ -474,7 +488,7 @@ final class DeptracExtensionTest extends TestCase
 
         $this->extension->load($configs, $this->container);
 
-        $expectedFormatterConfig = $this->formatterDefaults;
+        $expectedFormatterConfig = self::FORMATTER_DEFAULTS;
         $expectedFormatterConfig['graphviz'] = [
             'hidden_layers' => ['Utils'],
             'groups' => [
@@ -499,7 +513,7 @@ final class DeptracExtensionTest extends TestCase
 
         $this->extension->load($configs, $this->container);
 
-        $expectedFormatterConfig = $this->formatterDefaults;
+        $expectedFormatterConfig = self::FORMATTER_DEFAULTS;
         $actualFormatterConfig = $this->container->getParameter('formatters');
 
         krsort($expectedFormatterConfig);

--- a/tests/Supportive/DependencyInjection/DeptracExtensionTest.php
+++ b/tests/Supportive/DependencyInjection/DeptracExtensionTest.php
@@ -36,8 +36,10 @@ final class DeptracExtensionTest extends TestCase
     private const ANALYSER_DEFAULTS = [
         'internal_tag' => null,
         'types' => [
-            'class',
-            'function',
+            // Unfortunately, we can't use the enum type here, see
+            // https://wiki.php.net/rfc/fetch_property_in_const_expressions
+            'class',    // ClassLikeType::CLASS
+            'function', // ClassLikeType::FUNCTION
         ],
     ];
 


### PR DESCRIPTION
Make @internal tag configurable

Some projects, like MediaWiki, use the @internal tag with a different
semantics than the one imposed by deptrac. In the case of MediaWiki, the
intended semantics is "not for use by extensions", i.e. "internal to the
core repo".

To work around this issue, allow the config file to specify which tag
deptrac will interpret as "layer-internal". The @deptrac-internal tag
will continue to always work.
