### PR TITLE
Skip deprecated

### DIFF
--- a/config/services.php
+++ b/config/services.php
@@ -15,6 +15,7 @@ use Qossmic\Deptrac\Core\Analyser\EventHandler\AllowDependencyHandler;
 use Qossmic\Deptrac\Core\Analyser\EventHandler\DependsOnDisallowedLayer;
 use Qossmic\Deptrac\Core\Analyser\EventHandler\DependsOnInternalToken;
 use Qossmic\Deptrac\Core\Analyser\EventHandler\DependsOnPrivateLayer;
+use Qossmic\Deptrac\Core\Analyser\EventHandler\FromDeprecatedHandler;
 use Qossmic\Deptrac\Core\Analyser\EventHandler\MatchingLayersHandler;
 use Qossmic\Deptrac\Core\Analyser\EventHandler\UncoveredDependentHandler;
 use Qossmic\Deptrac\Core\Analyser\EventHandler\UnmatchedSkippedViolations;
@@ -323,6 +324,12 @@ return static function (ContainerConfigurator $container): void {
         ->tag('kernel.event_subscriber');
     $services
         ->set(MatchingLayersHandler::class)
+        ->tag('kernel.event_subscriber');
+    $services
+        ->set(FromDeprecatedHandler::class)
+        ->args([
+            '$config' => param('analyser'),
+        ])
         ->tag('kernel.event_subscriber');
     $services
         ->set(LayerProvider::class)

--- a/deptrac.config.php
+++ b/deptrac.config.php
@@ -19,6 +19,7 @@ return static function (DeptracConfig $config, ContainerConfigurator $containerC
 
     $config
         ->paths('src')
+        ->skipDeprecated()
         ->analyser(
             AnalyserConfig::create()
                 ->internalTag( '@internal' )

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -37,6 +37,21 @@ deptrac:
 </td>
 </tr>
 <tr>
+<td>analyser.skip_deprecated</td>
+<td>
+Instruct deptrac to skip violations originating from deprecated code.
+In other words, this allows deprecated code to depend on anything.
+</td>
+<td>
+
+```yaml
+deptrac:
+  analyser:
+    skip_deprecated: true
+```
+</td>
+</tr>
+<tr>
 <td>analyser.types</td>
 <td>
 

--- a/src/Contract/Config/DeptracConfig.php
+++ b/src/Contract/Config/DeptracConfig.php
@@ -21,7 +21,7 @@ final class DeptracConfig implements ConfigBuilderInterface
     private array $formatters = [];
     /** @var array<Ruleset> */
     private array $rulesets = [];
-    /** @var bool */
+
     private bool $skipDeprecated = false;
     private ?AnalyserConfig $analyser = null;
     /** @var array<string, array<string>> */
@@ -29,7 +29,7 @@ final class DeptracConfig implements ConfigBuilderInterface
     /** @var array<string> */
     private array $excludeFiles = [];
 
-    public function skipDeprecated(bool $skip=true): self
+    public function skipDeprecated(bool $skip = true): self
     {
         $this->skipDeprecated = $skip;
 

--- a/src/Contract/Config/DeptracConfig.php
+++ b/src/Contract/Config/DeptracConfig.php
@@ -21,11 +21,20 @@ final class DeptracConfig implements ConfigBuilderInterface
     private array $formatters = [];
     /** @var array<Ruleset> */
     private array $rulesets = [];
+    /** @var bool */
+    private bool $skipDeprecated = false;
     private ?AnalyserConfig $analyser = null;
     /** @var array<string, array<string>> */
     private array $skipViolations = [];
     /** @var array<string> */
     private array $excludeFiles = [];
+
+    public function skipDeprecated(bool $skip=true): self
+    {
+        $this->skipDeprecated = $skip;
+
+        return $this;
+    }
 
     /**
      * @deprecated use analyser(AnalyserConfig::create()) instead
@@ -113,6 +122,8 @@ final class DeptracConfig implements ConfigBuilderInterface
         if ([] !== $this->paths) {
             $config['paths'] = $this->paths;
         }
+
+        $config['analyser']['skip_deprecated'] = $this->skipDeprecated;
 
         if ($this->analyser) {
             $config['analyser'] = $this->analyser->toArray();

--- a/src/Core/Analyser/EventHandler/FromDeprecatedHandler.php
+++ b/src/Core/Analyser/EventHandler/FromDeprecatedHandler.php
@@ -1,0 +1,47 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Qossmic\Deptrac\Core\Analyser\EventHandler;
+
+use Qossmic\Deptrac\Contract\Analyser\ProcessEvent;
+use Qossmic\Deptrac\Core\Ast\AstMap\ClassLike\ClassLikeReference;
+use Symfony\Component\EventDispatcher\EventSubscriberInterface;
+
+/**
+ * Allow deprecated code to depend on anything.
+ *
+ * @internal
+ */
+class FromDeprecatedHandler implements EventSubscriberInterface
+{
+    private bool $enabled;
+
+    /**
+     * @param array{skip_deprecated: bool, ...} $config
+     */
+    public function __construct(array $config)
+    {
+        $this->enabled = $config['skip_deprecated'];
+    }
+
+    public function invoke(ProcessEvent $event): void
+    {
+        if (!$this->enabled) {
+            return;
+        }
+
+        $ref = $event->dependerReference;
+
+        if ($ref instanceof ClassLikeReference && ($ref->hasTag('@deprecated') ?? false)) {
+            $event->stopPropagation();
+        }
+    }
+
+    public static function getSubscribedEvents()
+    {
+        return [
+            ProcessEvent::class => ['invoke', 1],
+        ];
+    }
+}

--- a/src/Core/Analyser/EventHandler/FromDeprecatedHandler.php
+++ b/src/Core/Analyser/EventHandler/FromDeprecatedHandler.php
@@ -33,7 +33,7 @@ class FromDeprecatedHandler implements EventSubscriberInterface
 
         $ref = $event->dependerReference;
 
-        if ($ref instanceof ClassLikeReference && ($ref->hasTag('@deprecated') ?? false)) {
+        if ($ref instanceof ClassLikeReference && $ref->hasTag('@deprecated')) {
             $event->stopPropagation();
         }
     }

--- a/src/Supportive/DependencyInjection/Configuration.php
+++ b/src/Supportive/DependencyInjection/Configuration.php
@@ -210,6 +210,9 @@ class Configuration implements ConfigurationInterface
                         ->scalarNode('internal_tag')
                             ->defaultNull()
                             ->end()
+                        ->booleanNode('skip_deprecated')
+                            ->defaultValue(false)
+                            ->end()
                         ->arrayNode('types')
                             ->defaultValue([
                                 EmitterType::CLASS_TOKEN->value,

--- a/tests/Core/Analyser/EventHandler/FromDeprecatedHandlerTest.php
+++ b/tests/Core/Analyser/EventHandler/FromDeprecatedHandlerTest.php
@@ -1,0 +1,95 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Qossmic\Deptrac\Core\Analyser\EventHandler;
+
+use PHPUnit\Framework\TestCase;
+use Qossmic\Deptrac\Contract\Analyser\AnalysisResult;
+use Qossmic\Deptrac\Contract\Analyser\ProcessEvent;
+use Qossmic\Deptrac\Contract\Ast\DependencyType;
+use Qossmic\Deptrac\Contract\Ast\FileOccurrence;
+use Qossmic\Deptrac\Core\Analyser\EventHandler\FromDeprecatedHandler;
+use Qossmic\Deptrac\Core\Analyser\EventHandler\MatchingLayersHandler;
+use Qossmic\Deptrac\Core\Ast\AstMap\ClassLike\ClassLikeReference;
+use Qossmic\Deptrac\Core\Ast\AstMap\ClassLike\ClassLikeToken;
+use Qossmic\Deptrac\Core\Ast\AstMap\ClassLike\ClassLikeType;
+use Qossmic\Deptrac\Core\Dependency\Dependency;
+
+class FromDeprecatedHandlerTest extends TestCase
+{
+    public function testGetSubscribedEvents(): void
+    {
+        $subscribedEvents = MatchingLayersHandler::getSubscribedEvents();
+
+        self::assertCount(1, $subscribedEvents);
+        self::assertArrayHasKey(ProcessEvent::class, $subscribedEvents);
+        self::assertSame(['invoke', 1], $subscribedEvents[ProcessEvent::class]);
+    }
+
+    private function makeEvent(array $dependerTags, array $dependentTags): ProcessEvent
+    {
+        $dependerToken = ClassLikeToken::fromFQCN('DependerClass');
+        $dependentToken = ClassLikeToken::fromFQCN('DependentClass');
+
+        $event = new ProcessEvent(
+            new Dependency(
+                $dependerToken,
+                $dependentToken,
+                new FileOccurrence('test', 1),
+                DependencyType::STATIC_METHOD
+            ),
+            new ClassLikeReference($dependerToken, ClassLikeType::TYPE_CLASS,
+                [], [], $dependerTags),
+            'DependerLayer',
+            new ClassLikeReference($dependentToken, ClassLikeType::TYPE_CLASS,
+                [], [], $dependentTags),
+            ['DependentLayer'],
+            new AnalysisResult()
+        );
+
+        return $event;
+    }
+
+    public function testInvokeEnabled(): void
+    {
+        $handler = new FromDeprecatedHandler(['skip_deprecated' => true]);
+
+        $event = $this->makeEvent([], []);
+        $handler->invoke($event);
+
+        $this->assertFalse(
+            $event->isPropagationStopped(),
+            'Propagation should continue if neither reference has the "deprecated" tag'
+        );
+
+        $event = $this->makeEvent([], ['@deprecated' => '']);
+        $handler->invoke($event);
+
+        $this->assertFalse(
+            $event->isPropagationStopped(),
+            'Propagation should continue if only the dependent is deprecated'
+        );
+
+        $event = $this->makeEvent(['@deprecated' => ''], []);
+        $handler->invoke($event);
+
+        $this->assertTrue(
+            $event->isPropagationStopped(),
+            'Propagation should be stopped if the depender is deprecated'
+        );
+    }
+
+    public function testInvokeDisabled(): void
+    {
+        $handler = new FromDeprecatedHandler(['skip_deprecated' => false]);
+
+        $event = $this->makeEvent(['@deprecated' => ''], []);
+        $handler->invoke($event);
+
+        $this->assertFalse(
+            $event->isPropagationStopped(),
+            'Propagation should continue if skip_deprecated is false'
+        );
+    }
+}

--- a/tests/Supportive/DependencyInjection/DeptracExtensionTest.php
+++ b/tests/Supportive/DependencyInjection/DeptracExtensionTest.php
@@ -35,6 +35,7 @@ final class DeptracExtensionTest extends TestCase
 
     private const ANALYSER_DEFAULTS = [
         'internal_tag' => null,
+        'skip_deprecated' => false,
         'types' => [
             // Unfortunately, we can't use the enum type here, see
             // https://wiki.php.net/rfc/fetch_property_in_const_expressions


### PR DESCRIPTION
Allow deprecated code to be ignored

When refactoring a framework or library to improve layering, old code often cannot be removed immediately. Instead, it has to be marked as @deprecated, and kept around for a relase or two. When that is the case, we generally want to be able to ignore violations triggered by deprecated code, since we already know that we will remove it as soon as possible, and we want to focus on making the new code clean. Sometimes it's not even possible to avoid the offending dependency in the deprecated code, for structural reasons - that may well have been the reason for deprecating that code in the first place.

Handling of deprecation tags has been implemented following the example of isInternal. To avoid awkward method signatures with several booleanc params, ClassLikeReference has been changed to hold an array of tags, instead of a separate isDeprecated flag in addition to the existing isInternal flag.

TODO: Ignore code in deprecated methods, not just classes that are deprecated in their entirety.

NOTE: this goes on top of https://github.com/qossmic/deptrac/pull/1318