### PR TITLE
Remove dollar signs from readme.md console examples

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,17 +39,17 @@ is stored with the name `deptrac.yaml` in your project's root directory.
 Deptrac can generate a template for you, using the `init` command.
 
 ```console
-$ vendor/bin/deptrac init
+vendor/bin/deptrac init
 ```
 
 When you have this file, you can analyse your code by
 running the `analyse` command:
 
 ```console
-$ vendor/bin/deptrac
+vendor/bin/deptrac
 
 # which is equivalent to
-$ vendor/bin/deptrac analyse --config-file=deptrac.yaml
+vendor/bin/deptrac analyse --config-file=deptrac.yaml
 ```
 
 In order to run Deptrac you need at least PHP 8.1.


### PR DESCRIPTION
GitHub has added a copy command functionality leaving the dollar signs in adds friction when copying the commands