### PR TITLE
Define layers based on doc tags

### DIFF
--- a/tests/Core/Analyser/EventHandler/DependsOnInternalTokenTest.php
+++ b/tests/Core/Analyser/EventHandler/DependsOnInternalTokenTest.php
@@ -17,7 +17,7 @@ use Qossmic\Deptrac\Core\Ast\AstMap\ClassLike\ClassLikeToken;
 use Qossmic\Deptrac\Core\Ast\AstMap\ClassLike\ClassLikeType;
 use Qossmic\Deptrac\Core\Dependency\Dependency;
 
-class DependsOnInternalTokenTest extends TestCase
+final class DependsOnInternalTokenTest extends TestCase
 {
     public function testGetSubscribedEvents(): void
     {

--- a/tests/Core/Ast/Parser/NikicPhpParser/NikicPhpParserTest.php
+++ b/tests/Core/Ast/Parser/NikicPhpParser/NikicPhpParserTest.php
@@ -62,7 +62,10 @@ final class NikicPhpParserTest extends TestCase
     {
         $typeResolver = new TypeResolver();
         $parser = new NikicPhpParser(
-            (new ParserFactory())->create(ParserFactory::ONLY_PHP7, new Lexer()),
+            (new ParserFactory())->create(
+                ParserFactory::ONLY_PHP7,
+                new Lexer()
+            ),
             new AstFileReferenceInMemoryCache(),
             $typeResolver,
             [new AnnotationReferenceExtractor($typeResolver)]

--- a/tests/Core/Ast/Parser/NikicPhpParser/NikicPhpParserTest.php
+++ b/tests/Core/Ast/Parser/NikicPhpParser/NikicPhpParserTest.php
@@ -37,7 +37,7 @@ final class NikicPhpParserTest extends TestCase
 
     public function testParseDoesNotIgnoreUsesByDefault(): void
     {
-        $parser = $this->getParser();
+        $parser = $this->createParser();
 
         $filePath = __DIR__.'/Fixtures/CountingUseStatements.php';
         self::assertCount(1, $parser->parseFile($filePath)->dependencies);
@@ -48,7 +48,7 @@ final class NikicPhpParserTest extends TestCase
      */
     public function testParseAttributes(): void
     {
-        $parser = $this->getParser();
+        $parser = $this->createParser();
 
         $filePath = __DIR__.'/Fixtures/Attributes.php';
         $astFileReference = $parser->parseFile($filePath);
@@ -76,7 +76,7 @@ final class NikicPhpParserTest extends TestCase
 
     public function testParseClassDocTags(): void
     {
-        $parser = $this->getParser();
+        $parser = $this->createParser();
         $filePath = __DIR__.'/Fixtures/DocTags.php';
         $astFileReference = $parser->parseFile($filePath);
 
@@ -95,7 +95,7 @@ final class NikicPhpParserTest extends TestCase
 
     public function testParseFunctionDocTags(): void
     {
-        $parser = $this->getParser();
+        $parser = $this->createParser();
         $filePath = __DIR__.'/Fixtures/Functions.php';
         $astFileReference = $parser->parseFile($filePath);
 
@@ -121,7 +121,7 @@ final class NikicPhpParserTest extends TestCase
         return $refsByName;
     }
 
-    private function getParser(): NikicPhpParser
+    private function createParser(): NikicPhpParser
     {
         $typeResolver = new TypeResolver();
         $parser = new NikicPhpParser(

--- a/tests/Core/Layer/Collector/TagValueRegexCollectorTest.php
+++ b/tests/Core/Layer/Collector/TagValueRegexCollectorTest.php
@@ -27,12 +27,12 @@ final class TagValueRegexCollectorTest extends TestCase
     {
         yield 'match tag name, no value' => [
             TagValueRegexConfig::create('@foo'),
-            ['@foo' => ['']]
+            ['@foo' => ['']],
         ];
 
         yield 'match tag name, any value' => [
             TagValueRegexConfig::create('@foo'),
-            ['@foo' => ['anything']]
+            ['@foo' => ['anything']],
         ];
 
         yield 'match tag name and value' => [
@@ -63,7 +63,7 @@ final class TagValueRegexCollectorTest extends TestCase
     {
         yield 'tag name mismatch' => [
             TagValueRegexConfig::create('@foo'),
-            ['@bar' => ['anything']]
+            ['@bar' => ['anything']],
         ];
 
         yield 'value mismatch' => [

--- a/tests/Core/Layer/Collector/TagValueRegexCollectorTest.php
+++ b/tests/Core/Layer/Collector/TagValueRegexCollectorTest.php
@@ -25,16 +25,22 @@ final class TagValueRegexCollectorTest extends TestCase
 
     public static function dataProviderSatisfy(): iterable
     {
-        yield [TagValueRegexConfig::create('@foo'), ['@foo' => ['']]];
+        yield 'match tag name, no value' => [
+            TagValueRegexConfig::create('@foo'),
+            ['@foo' => ['']]
+        ];
 
-        yield [TagValueRegexConfig::create('@foo'), ['@foo' => ['anything']]];
+        yield 'match tag name, any value' => [
+            TagValueRegexConfig::create('@foo'),
+            ['@foo' => ['anything']]
+        ];
 
-        yield [
+        yield 'match tag name and value' => [
             TagValueRegexConfig::create('@foo-bar', '/some/'),
             ['@xyz' => [''], '@foo-bar' => ['anything', 'something']],
         ];
 
-        yield [
+        yield 'match value with anchored regex' => [
             TagValueRegexConfig::create('@foo-bar')->match('!thing$!'),
             ['@xyz' => [''], '@foo-bar' => ['anything', 'something']],
         ];
@@ -55,13 +61,16 @@ final class TagValueRegexCollectorTest extends TestCase
 
     public static function dataProviderNotSatisfy(): iterable
     {
-        yield [TagValueRegexConfig::create('@foo'), ['@bar' => ['anything']]];
+        yield 'tag name mismatch' => [
+            TagValueRegexConfig::create('@foo'),
+            ['@bar' => ['anything']]
+        ];
 
-        yield [
+        yield 'value mismatch' => [
             TagValueRegexConfig::create('@foo', '/something/'),
             ['@xyz' => [''], '@foo' => ['anything', 'another thing']],
         ];
-        yield [
+        yield 'anchored regex' => [
             TagValueRegexConfig::create('@foo', '/^thing/'),
             ['@xyz' => [''], '@foo' => ['anything', 'another thing']],
         ];


### PR DESCRIPTION
This PR introduces a TagValueRegexCollector that allows layers to be defined based on the presence or value of doc tags like @deprecated.

All tags present in the doc block are exposed on ClassLikeReference and FunctionReference, for use by collectors and event handlers.

Note that this changs the way #1319 and #1318 should be implemented.