### PR TITLE
Allow deprecated code to be ignored

### DIFF
--- a/config/services.php
+++ b/config/services.php
@@ -161,6 +161,7 @@ return static function (ContainerConfigurator $container): void {
         ->set(NikicPhpParser::class)
         ->args([
             '$extractors' => tagged_iterator('reference_extractors'),
+            '$config' => param('analyser'),
         ]);
     $services->alias(ParserInterface::class, NikicPhpParser::class);
     $services->set(TypeResolver::class);

--- a/deptrac.config.php
+++ b/deptrac.config.php
@@ -19,6 +19,7 @@ return static function (DeptracConfig $config, ContainerConfigurator $containerC
 
     $config
         ->paths('src')
+        ->skipDeprecated()
         ->analyser(
             AnalyserConfig::create()
                 ->internalTag( '@internal' )

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -37,6 +37,21 @@ deptrac:
 </td>
 </tr>
 <tr>
+<td>analyser.skip_deprecated</td>
+<td>
+Instruct deptrac to skip violations originating from deprecated code.
+In other words, this allows deprecated code to depend on anything.
+</td>
+<td>
+
+```yaml
+deptrac:
+  analyser:
+    skip_deprecated: true
+```
+</td>
+</tr>
+<tr>
 <td>analyser.types</td>
 <td>
 

--- a/src/Contract/Config/DeptracConfig.php
+++ b/src/Contract/Config/DeptracConfig.php
@@ -21,11 +21,20 @@ final class DeptracConfig implements ConfigBuilderInterface
     private array $formatters = [];
     /** @var array<Ruleset> */
     private array $rulesets = [];
+
+    private bool $skipDeprecated = false;
     private ?AnalyserConfig $analyser = null;
     /** @var array<string, array<string>> */
     private array $skipViolations = [];
     /** @var array<string> */
     private array $excludeFiles = [];
+
+    public function skipDeprecated(bool $skip = true): self
+    {
+        $this->skipDeprecated = $skip;
+
+        return $this;
+    }
 
     /**
      * @deprecated use analyser(AnalyserConfig::create()) instead
@@ -113,6 +122,8 @@ final class DeptracConfig implements ConfigBuilderInterface
         if ([] !== $this->paths) {
             $config['paths'] = $this->paths;
         }
+
+        $config['analyser']['skip_deprecated'] = $this->skipDeprecated;
 
         if ($this->analyser) {
             $config['analyser'] = $this->analyser->toArray();

--- a/src/Core/Ast/AstMap/DisabledReferenceBuilder.php
+++ b/src/Core/Ast/AstMap/DisabledReferenceBuilder.php
@@ -1,0 +1,102 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Qossmic\Deptrac\Core\Ast\AstMap;
+
+/**
+ * A ReferenceBuilder that will ignore all dependencies.
+ */
+class DisabledReferenceBuilder extends ReferenceBuilder
+{
+    public function unresolvedFunctionCall(string $functionName, int $occursAtLine): self
+    {
+        // no-op
+        return $this;
+    }
+
+    public function variable(string $classLikeName, int $occursAtLine): self
+    {
+        // no-op
+        return $this;
+    }
+
+    public function superglobal(string $superglobalName, int $occursAtLine): void
+    {
+        // no-op
+    }
+
+    public function returnType(string $classLikeName, int $occursAtLine): self
+    {
+        // no-op
+        return $this;
+    }
+
+    public function throwStatement(string $classLikeName, int $occursAtLine): self
+    {
+        // no-op
+        return $this;
+    }
+
+    public function anonymousClassExtends(string $classLikeName, int $occursAtLine): void
+    {
+        // no-op
+    }
+
+    public function anonymousClassTrait(string $classLikeName, int $occursAtLine): void
+    {
+        // no-op
+    }
+
+    public function constFetch(string $classLikeName, int $occursAtLine): void
+    {
+        // no-op
+    }
+
+    public function anonymousClassImplements(string $classLikeName, int $occursAtLine): void
+    {
+        // no-op
+    }
+
+    public function parameter(string $classLikeName, int $occursAtLine): self
+    {
+        // no-op
+        return $this;
+    }
+
+    public function attribute(string $classLikeName, int $occursAtLine): self
+    {
+        // no-op
+        return $this;
+    }
+
+    public function instanceof(string $classLikeName, int $occursAtLine): self
+    {
+        // no-op
+        return $this;
+    }
+
+    public function newStatement(string $classLikeName, int $occursAtLine): self
+    {
+        // no-op
+        return $this;
+    }
+
+    public function staticProperty(string $classLikeName, int $occursAtLine): self
+    {
+        // no-op
+        return $this;
+    }
+
+    public function staticMethod(string $classLikeName, int $occursAtLine): self
+    {
+        // no-op
+        return $this;
+    }
+
+    public function catchStmt(string $classLikeName, int $occursAtLine): self
+    {
+        // no-op
+        return $this;
+    }
+}

--- a/src/Core/Ast/AstMap/File/FileReferenceBuilder.php
+++ b/src/Core/Ast/AstMap/File/FileReferenceBuilder.php
@@ -9,6 +9,7 @@ use Qossmic\Deptrac\Contract\Ast\FileOccurrence;
 use Qossmic\Deptrac\Core\Ast\AstMap\ClassLike\ClassLikeReferenceBuilder;
 use Qossmic\Deptrac\Core\Ast\AstMap\ClassLike\ClassLikeToken;
 use Qossmic\Deptrac\Core\Ast\AstMap\DependencyToken;
+use Qossmic\Deptrac\Core\Ast\AstMap\DisabledReferenceBuilder;
 use Qossmic\Deptrac\Core\Ast\AstMap\Function\FunctionReferenceBuilder;
 use Qossmic\Deptrac\Core\Ast\AstMap\ReferenceBuilder;
 
@@ -94,6 +95,11 @@ final class FileReferenceBuilder extends ReferenceBuilder
         $this->functionReferences[] = $functionReference;
 
         return $functionReference;
+    }
+
+    public function newDisabled(): DisabledReferenceBuilder
+    {
+        return new DisabledReferenceBuilder([], $this->filepath);
     }
 
     public function build(): FileReference

--- a/src/Core/Ast/Parser/NikicPhpParser/NikicPhpParser.php
+++ b/src/Core/Ast/Parser/NikicPhpParser/NikicPhpParser.php
@@ -34,13 +34,15 @@ class NikicPhpParser implements ParserInterface
     private readonly NodeTraverser $traverser;
 
     /**
+     * @param array{skip_deprecated: bool,...} $config
      * @param ReferenceExtractorInterface[] $extractors
      */
     public function __construct(
         private readonly Parser $parser,
         private readonly AstFileReferenceCacheInterface $cache,
         private readonly TypeResolver $typeResolver,
-        private readonly iterable $extractors
+        private readonly array $config,
+        private readonly iterable $extractors,
     ) {
         $this->traverser = new NodeTraverser();
         $this->traverser->addVisitor(new NameResolver());
@@ -53,7 +55,12 @@ class NikicPhpParser implements ParserInterface
         }
 
         $fileReferenceBuilder = FileReferenceBuilder::create($file);
-        $visitor = new FileReferenceVisitor($fileReferenceBuilder, $this->typeResolver, ...$this->extractors);
+        $visitor = new FileReferenceVisitor(
+            $fileReferenceBuilder,
+            $this->typeResolver,
+            $this->config,
+            ...$this->extractors
+        );
         $nodes = $this->loadNodesFromFile($file);
         $this->traverser->addVisitor($visitor);
         $this->traverser->traverse($nodes);

--- a/src/Supportive/DependencyInjection/Configuration.php
+++ b/src/Supportive/DependencyInjection/Configuration.php
@@ -210,6 +210,9 @@ class Configuration implements ConfigurationInterface
                         ->scalarNode('internal_tag')
                             ->defaultNull()
                             ->end()
+                        ->booleanNode('skip_deprecated')
+                            ->defaultValue(false)
+                            ->end()
                         ->arrayNode('types')
                             ->defaultValue([
                                 EmitterType::CLASS_TOKEN->value,

--- a/tests/Core/Ast/AstMapFlattenGeneratorTest.php
+++ b/tests/Core/Ast/AstMapFlattenGeneratorTest.php
@@ -62,6 +62,7 @@ final class AstMapFlattenGeneratorTest extends TestCase
                 (new ParserFactory())->create(ParserFactory::ONLY_PHP7, new Lexer()),
                 new AstFileReferenceInMemoryCache(),
                 new TypeResolver(),
+                [],
                 []
             ),
             $this->eventDispatcher

--- a/tests/Core/Ast/AstMapGeneratorTest.php
+++ b/tests/Core/Ast/AstMapGeneratorTest.php
@@ -40,6 +40,7 @@ final class AstMapGeneratorTest extends TestCase
                 (new ParserFactory())->create(ParserFactory::ONLY_PHP7, new Lexer()),
                 new AstFileReferenceInMemoryCache(),
                 $typeResolver,
+                [],
                 [
                     new AnnotationReferenceExtractor($typeResolver),
                     new AnonymousClassExtractor(),

--- a/tests/Core/Ast/Parser/AnnotationReferenceExtractorTest.php
+++ b/tests/Core/Ast/Parser/AnnotationReferenceExtractorTest.php
@@ -22,6 +22,7 @@ final class AnnotationReferenceExtractorTest extends TestCase
             (new ParserFactory())->create(ParserFactory::ONLY_PHP7, new Lexer()),
             new AstFileReferenceInMemoryCache(),
             new TypeResolver(),
+            [],
             [
                 new AnnotationReferenceExtractor($typeResolver),
                 new KeywordExtractor($typeResolver),

--- a/tests/Core/Ast/Parser/AnonymousClassExtractorTest.php
+++ b/tests/Core/Ast/Parser/AnonymousClassExtractorTest.php
@@ -20,6 +20,7 @@ final class AnonymousClassExtractorTest extends TestCase
             (new ParserFactory())->create(ParserFactory::ONLY_PHP7, new Lexer()),
             new AstFileReferenceInMemoryCache(),
             new TypeResolver(),
+            [],
             [
                 new AnonymousClassExtractor(),
             ]

--- a/tests/Core/Ast/Parser/ClassConstantExtractorTest.php
+++ b/tests/Core/Ast/Parser/ClassConstantExtractorTest.php
@@ -20,6 +20,7 @@ final class ClassConstantExtractorTest extends TestCase
             (new ParserFactory())->create(ParserFactory::ONLY_PHP7, new Lexer()),
             new AstFileReferenceInMemoryCache(),
             new TypeResolver(),
+            [],
             [
                 new ClassConstantExtractor(),
             ]

--- a/tests/Core/Ast/Parser/ClassDocBlockExtractorTest.php
+++ b/tests/Core/Ast/Parser/ClassDocBlockExtractorTest.php
@@ -30,6 +30,7 @@ final class ClassDocBlockExtractorTest extends TestCase
             (new ParserFactory())->create(ParserFactory::ONLY_PHP7, new Lexer()),
             new AstFileReferenceInMemoryCache(),
             $typeResolver,
+            [],
             [
                 new KeywordExtractor($typeResolver),
             ]

--- a/tests/Core/Ast/Parser/NikicPhpParser/Fixtures/Deprecations.php
+++ b/tests/Core/Ast/Parser/NikicPhpParser/Fixtures/Deprecations.php
@@ -1,0 +1,29 @@
+<?php
+
+declare(strict_types = 1);
+
+namespace Tests\Qossmic\Deptrac\Core\Ast\Parser\NikicPhpParser\Fixtures;
+
+/**
+ * @deprecated for testing
+ */
+class DeprecatedClass extends UndeprecatedClass
+{
+    public function someMethod(AnotherThing $x) {}
+}
+
+class UndeprecatedClass
+{
+    #[\Deprecated]
+    public function deprecatedMethod(Something $x) {}
+
+    public function notDeprecated(AnotherThing $x) {}
+}
+
+class Something
+{
+}
+
+class AnotherThing
+{
+}

--- a/tests/Core/Dependency/Emitter/EmitterTrait.php
+++ b/tests/Core/Dependency/Emitter/EmitterTrait.php
@@ -36,6 +36,7 @@ trait EmitterTrait
             (new ParserFactory())->create(ParserFactory::ONLY_PHP7, new Lexer()),
             new AstFileReferenceInMemoryCache(),
             $typeResolver,
+            [],
             [
                 new AnonymousClassExtractor(),
                 new FunctionLikeExtractor($typeResolver),

--- a/tests/Supportive/DependencyInjection/DeptracExtensionTest.php
+++ b/tests/Supportive/DependencyInjection/DeptracExtensionTest.php
@@ -35,6 +35,7 @@ final class DeptracExtensionTest extends TestCase
 
     private const ANALYSER_DEFAULTS = [
         'internal_tag' => null,
+        'skip_deprecated' => false,
         'types' => [
             // Unfortunately, we can't use the enum type here, see
             // https://wiki.php.net/rfc/fetch_property_in_const_expressions


### PR DESCRIPTION
When refactoring a framework or library to improve layering, old code often cannot be removed immediately. Instead, it has to be marked as @deprecated, and kept around for a relase or two. When that is the case, we generally want to be able to ignore violations triggered by deprecated code, since we already know that we will remove it as soon as possible, and we want to focus on making the new code clean. Sometimes it's not even possible to avoid the offending dependency in the deprecated code, for structural reasons - that may well have been the reason for deprecating that code in the first place.

The detection logic for deprecated methods and classes is built directly into FilweReferenceVisitor. That's not great, but serves as a proof of concept.