### PR TITLE
Refactor DependencyInterface 

### DIFF
--- a/src/Contract/Ast/DependencyContext.php
+++ b/src/Contract/Ast/DependencyContext.php
@@ -1,0 +1,20 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Qossmic\Deptrac\Contract\Ast;
+
+/**
+ * @psalm-immutable
+ *
+ * Context of the dependency.
+ *
+ * Any additional info about where the dependency occurred.
+ */
+final class DependencyContext
+{
+    public function __construct(
+        public readonly FileOccurrence $fileOccurrence,
+        public readonly DependencyType $dependencyType
+    ) {}
+}

--- a/src/Contract/Dependency/DependencyInterface.php
+++ b/src/Contract/Dependency/DependencyInterface.php
@@ -4,8 +4,7 @@ declare(strict_types=1);
 
 namespace Qossmic\Deptrac\Contract\Dependency;
 
-use Qossmic\Deptrac\Contract\Ast\DependencyType;
-use Qossmic\Deptrac\Contract\Ast\FileOccurrence;
+use Qossmic\Deptrac\Contract\Ast\DependencyContext;
 use Qossmic\Deptrac\Contract\Ast\TokenInterface;
 
 /**
@@ -17,12 +16,10 @@ interface DependencyInterface
 
     public function getDependent(): TokenInterface;
 
-    public function getFileOccurrence(): FileOccurrence;
+    public function getContext(): DependencyContext;
 
     /**
      * @return array<array{name:string, line:int}>
      */
     public function serialize(): array;
-
-    public function getType(): DependencyType;
 }

--- a/src/Core/Ast/AstMap/DependencyToken.php
+++ b/src/Core/Ast/AstMap/DependencyToken.php
@@ -4,8 +4,7 @@ declare(strict_types=1);
 
 namespace Qossmic\Deptrac\Core\Ast\AstMap;
 
-use Qossmic\Deptrac\Contract\Ast\DependencyType;
-use Qossmic\Deptrac\Contract\Ast\FileOccurrence;
+use Qossmic\Deptrac\Contract\Ast\DependencyContext;
 use Qossmic\Deptrac\Contract\Ast\TokenInterface;
 
 /**
@@ -15,7 +14,6 @@ class DependencyToken
 {
     public function __construct(
         public readonly TokenInterface $token,
-        public readonly FileOccurrence $fileOccurrence,
-        public readonly DependencyType $type
+        public readonly DependencyContext $context,
     ) {}
 }

--- a/src/Core/Ast/AstMap/File/FileReferenceBuilder.php
+++ b/src/Core/Ast/AstMap/File/FileReferenceBuilder.php
@@ -5,7 +5,6 @@ declare(strict_types=1);
 namespace Qossmic\Deptrac\Core\Ast\AstMap\File;
 
 use Qossmic\Deptrac\Contract\Ast\DependencyType;
-use Qossmic\Deptrac\Contract\Ast\FileOccurrence;
 use Qossmic\Deptrac\Core\Ast\AstMap\ClassLike\ClassLikeReferenceBuilder;
 use Qossmic\Deptrac\Core\Ast\AstMap\ClassLike\ClassLikeToken;
 use Qossmic\Deptrac\Core\Ast\AstMap\DependencyToken;
@@ -29,8 +28,7 @@ final class FileReferenceBuilder extends ReferenceBuilder
     {
         $this->dependencies[] = new DependencyToken(
             ClassLikeToken::fromFQCN($classLikeName),
-            new FileOccurrence($this->filepath, $occursAtLine),
-            DependencyType::USE
+            $this->createContext($occursAtLine, DependencyType::USE),
         );
 
         return $this;

--- a/src/Core/Ast/AstMap/ReferenceBuilder.php
+++ b/src/Core/Ast/AstMap/ReferenceBuilder.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace Qossmic\Deptrac\Core\Ast\AstMap;
 
+use Qossmic\Deptrac\Contract\Ast\DependencyContext;
 use Qossmic\Deptrac\Contract\Ast\DependencyType;
 use Qossmic\Deptrac\Contract\Ast\FileOccurrence;
 use Qossmic\Deptrac\Core\Ast\AstMap\ClassLike\ClassLikeToken;
@@ -28,6 +29,11 @@ abstract class ReferenceBuilder
         return $this->tokenTemplates;
     }
 
+    protected function createContext(int $occursAtLine, DependencyType $type): DependencyContext
+    {
+        return new DependencyContext(new FileOccurrence($this->filepath, $occursAtLine), $type);
+    }
+
     /**
      * Unqualified function and constant names inside a namespace cannot be
      * statically resolved. Inside a namespace Foo, a call to strlen() may
@@ -39,8 +45,7 @@ abstract class ReferenceBuilder
     {
         $this->dependencies[] = new DependencyToken(
             FunctionToken::fromFQCN($functionName),
-            new FileOccurrence($this->filepath, $occursAtLine),
-            DependencyType::UNRESOLVED_FUNCTION_CALL
+            $this->createContext($occursAtLine, DependencyType::UNRESOLVED_FUNCTION_CALL),
         );
 
         return $this;
@@ -50,8 +55,7 @@ abstract class ReferenceBuilder
     {
         $this->dependencies[] = new DependencyToken(
             ClassLikeToken::fromFQCN($classLikeName),
-            new FileOccurrence($this->filepath, $occursAtLine),
-            DependencyType::VARIABLE
+            $this->createContext($occursAtLine, DependencyType::VARIABLE),
         );
 
         return $this;
@@ -61,8 +65,7 @@ abstract class ReferenceBuilder
     {
         $this->dependencies[] = new DependencyToken(
             SuperGlobalToken::from($superglobalName),
-            new FileOccurrence($this->filepath, $occursAtLine),
-            DependencyType::SUPERGLOBAL_VARIABLE
+            $this->createContext($occursAtLine, DependencyType::SUPERGLOBAL_VARIABLE),
         );
     }
 
@@ -70,8 +73,7 @@ abstract class ReferenceBuilder
     {
         $this->dependencies[] = new DependencyToken(
             ClassLikeToken::fromFQCN($classLikeName),
-            new FileOccurrence($this->filepath, $occursAtLine),
-            DependencyType::RETURN_TYPE
+            $this->createContext($occursAtLine, DependencyType::RETURN_TYPE),
         );
 
         return $this;
@@ -81,8 +83,7 @@ abstract class ReferenceBuilder
     {
         $this->dependencies[] = new DependencyToken(
             ClassLikeToken::fromFQCN($classLikeName),
-            new FileOccurrence($this->filepath, $occursAtLine),
-            DependencyType::THROW
+            $this->createContext($occursAtLine, DependencyType::THROW),
         );
 
         return $this;
@@ -92,8 +93,7 @@ abstract class ReferenceBuilder
     {
         $this->dependencies[] = new DependencyToken(
             ClassLikeToken::fromFQCN($classLikeName),
-            new FileOccurrence($this->filepath, $occursAtLine),
-            DependencyType::ANONYMOUS_CLASS_EXTENDS
+            $this->createContext($occursAtLine, DependencyType::ANONYMOUS_CLASS_EXTENDS),
         );
     }
 
@@ -101,8 +101,7 @@ abstract class ReferenceBuilder
     {
         $this->dependencies[] = new DependencyToken(
             ClassLikeToken::fromFQCN($classLikeName),
-            new FileOccurrence($this->filepath, $occursAtLine),
-            DependencyType::ANONYMOUS_CLASS_TRAIT
+            $this->createContext($occursAtLine, DependencyType::ANONYMOUS_CLASS_TRAIT),
         );
     }
 
@@ -110,8 +109,7 @@ abstract class ReferenceBuilder
     {
         $this->dependencies[] = new DependencyToken(
             ClassLikeToken::fromFQCN($classLikeName),
-            new FileOccurrence($this->filepath, $occursAtLine),
-            DependencyType::CONST
+            $this->createContext($occursAtLine, DependencyType::CONST),
         );
     }
 
@@ -119,8 +117,7 @@ abstract class ReferenceBuilder
     {
         $this->dependencies[] = new DependencyToken(
             ClassLikeToken::fromFQCN($classLikeName),
-            new FileOccurrence($this->filepath, $occursAtLine),
-            DependencyType::ANONYMOUS_CLASS_IMPLEMENTS
+            $this->createContext($occursAtLine, DependencyType::ANONYMOUS_CLASS_IMPLEMENTS),
         );
     }
 
@@ -128,8 +125,7 @@ abstract class ReferenceBuilder
     {
         $this->dependencies[] = new DependencyToken(
             ClassLikeToken::fromFQCN($classLikeName),
-            new FileOccurrence($this->filepath, $occursAtLine),
-            DependencyType::PARAMETER
+            $this->createContext($occursAtLine, DependencyType::PARAMETER),
         );
 
         return $this;
@@ -139,8 +135,7 @@ abstract class ReferenceBuilder
     {
         $this->dependencies[] = new DependencyToken(
             ClassLikeToken::fromFQCN($classLikeName),
-            new FileOccurrence($this->filepath, $occursAtLine),
-            DependencyType::ATTRIBUTE
+            $this->createContext($occursAtLine, DependencyType::ATTRIBUTE),
         );
 
         return $this;
@@ -150,8 +145,7 @@ abstract class ReferenceBuilder
     {
         $this->dependencies[] = new DependencyToken(
             ClassLikeToken::fromFQCN($classLikeName),
-            new FileOccurrence($this->filepath, $occursAtLine),
-            DependencyType::INSTANCEOF
+            $this->createContext($occursAtLine, DependencyType::INSTANCEOF),
         );
 
         return $this;
@@ -161,8 +155,7 @@ abstract class ReferenceBuilder
     {
         $this->dependencies[] = new DependencyToken(
             ClassLikeToken::fromFQCN($classLikeName),
-            new FileOccurrence($this->filepath, $occursAtLine),
-            DependencyType::NEW
+            $this->createContext($occursAtLine, DependencyType::NEW),
         );
 
         return $this;
@@ -172,8 +165,7 @@ abstract class ReferenceBuilder
     {
         $this->dependencies[] = new DependencyToken(
             ClassLikeToken::fromFQCN($classLikeName),
-            new FileOccurrence($this->filepath, $occursAtLine),
-            DependencyType::STATIC_PROPERTY
+            $this->createContext($occursAtLine, DependencyType::STATIC_PROPERTY),
         );
 
         return $this;
@@ -183,8 +175,7 @@ abstract class ReferenceBuilder
     {
         $this->dependencies[] = new DependencyToken(
             ClassLikeToken::fromFQCN($classLikeName),
-            new FileOccurrence($this->filepath, $occursAtLine),
-            DependencyType::STATIC_METHOD
+            $this->createContext($occursAtLine, DependencyType::STATIC_METHOD),
         );
 
         return $this;
@@ -194,8 +185,7 @@ abstract class ReferenceBuilder
     {
         $this->dependencies[] = new DependencyToken(
             ClassLikeToken::fromFQCN($classLikeName),
-            new FileOccurrence($this->filepath, $occursAtLine),
-            DependencyType::CATCH
+            $this->createContext($occursAtLine, DependencyType::CATCH),
         );
 
         return $this;

--- a/src/Core/Ast/Parser/Cache/AstFileReferenceFileCache.php
+++ b/src/Core/Ast/Parser/Cache/AstFileReferenceFileCache.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace Qossmic\Deptrac\Core\Ast\Parser\Cache;
 
+use Qossmic\Deptrac\Contract\Ast\DependencyContext;
 use Qossmic\Deptrac\Contract\Ast\DependencyType;
 use Qossmic\Deptrac\Contract\Ast\FileOccurrence;
 use Qossmic\Deptrac\Core\Ast\AstMap\AstInherit;
@@ -121,6 +122,7 @@ class AstFileReferenceFileCache implements AstFileReferenceDeferredCacheInterfac
                             FunctionToken::class,
                             SuperGlobalToken::class,
                             FileOccurrence::class,
+                            DependencyContext::class,
                         ],
                     ]
                 );

--- a/src/Core/Dependency/Dependency.php
+++ b/src/Core/Dependency/Dependency.php
@@ -4,8 +4,7 @@ declare(strict_types=1);
 
 namespace Qossmic\Deptrac\Core\Dependency;
 
-use Qossmic\Deptrac\Contract\Ast\DependencyType;
-use Qossmic\Deptrac\Contract\Ast\FileOccurrence;
+use Qossmic\Deptrac\Contract\Ast\DependencyContext;
 use Qossmic\Deptrac\Contract\Ast\TokenInterface;
 use Qossmic\Deptrac\Contract\Dependency\DependencyInterface;
 
@@ -14,15 +13,14 @@ class Dependency implements DependencyInterface
     public function __construct(
         private readonly TokenInterface $depender,
         private readonly TokenInterface $dependent,
-        private readonly FileOccurrence $fileOccurrence,
-        private readonly DependencyType $dependencyType
+        private readonly DependencyContext $context,
     ) {}
 
     public function serialize(): array
     {
         return [[
             'name' => $this->dependent->toString(),
-            'line' => $this->fileOccurrence->line,
+            'line' => $this->context->fileOccurrence->line,
         ]];
     }
 
@@ -36,13 +34,8 @@ class Dependency implements DependencyInterface
         return $this->dependent;
     }
 
-    public function getFileOccurrence(): FileOccurrence
+    public function getContext(): DependencyContext
     {
-        return $this->fileOccurrence;
-    }
-
-    public function getType(): DependencyType
-    {
-        return $this->dependencyType;
+        return $this->context;
     }
 }

--- a/src/Core/Dependency/Emitter/ClassDependencyEmitter.php
+++ b/src/Core/Dependency/Emitter/ClassDependencyEmitter.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace Qossmic\Deptrac\Core\Dependency\Emitter;
 
+use Qossmic\Deptrac\Contract\Ast\DependencyContext;
 use Qossmic\Deptrac\Contract\Ast\DependencyType;
 use Qossmic\Deptrac\Core\Ast\AstMap\AstMap;
 use Qossmic\Deptrac\Core\Dependency\Dependency;
@@ -22,10 +23,10 @@ final class ClassDependencyEmitter implements DependencyEmitterInterface
             $classLikeName = $classReference->getToken();
 
             foreach ($classReference->dependencies as $dependency) {
-                if (DependencyType::SUPERGLOBAL_VARIABLE === $dependency->type) {
+                if (DependencyType::SUPERGLOBAL_VARIABLE === $dependency->context->dependencyType) {
                     continue;
                 }
-                if (DependencyType::UNRESOLVED_FUNCTION_CALL === $dependency->type) {
+                if (DependencyType::UNRESOLVED_FUNCTION_CALL === $dependency->context->dependencyType) {
                     continue;
                 }
 
@@ -33,8 +34,7 @@ final class ClassDependencyEmitter implements DependencyEmitterInterface
                     new Dependency(
                         $classLikeName,
                         $dependency->token,
-                        $dependency->fileOccurrence,
-                        $dependency->type
+                        $dependency->context,
                     )
                 );
             }
@@ -44,8 +44,7 @@ final class ClassDependencyEmitter implements DependencyEmitterInterface
                     new Dependency(
                         $classLikeName,
                         $inherit->classLikeName,
-                        $inherit->fileOccurrence,
-                        DependencyType::INHERIT
+                        new DependencyContext($inherit->fileOccurrence, DependencyType::INHERIT),
                     )
                 );
             }

--- a/src/Core/Dependency/Emitter/ClassSuperglobalDependencyEmitter.php
+++ b/src/Core/Dependency/Emitter/ClassSuperglobalDependencyEmitter.php
@@ -20,15 +20,14 @@ final class ClassSuperglobalDependencyEmitter implements DependencyEmitterInterf
     {
         foreach ($astMap->getClassLikeReferences() as $classReference) {
             foreach ($classReference->dependencies as $dependency) {
-                if (DependencyType::SUPERGLOBAL_VARIABLE !== $dependency->type) {
+                if (DependencyType::SUPERGLOBAL_VARIABLE !== $dependency->context->dependencyType) {
                     continue;
                 }
                 $dependencyList->addDependency(
                     new Dependency(
                         $classReference->getToken(),
                         $dependency->token,
-                        $dependency->fileOccurrence,
-                        $dependency->type
+                        $dependency->context,
                     )
                 );
             }

--- a/src/Core/Dependency/Emitter/FileDependencyEmitter.php
+++ b/src/Core/Dependency/Emitter/FileDependencyEmitter.php
@@ -20,11 +20,11 @@ final class FileDependencyEmitter implements DependencyEmitterInterface
     {
         foreach ($astMap->getFileReferences() as $fileReference) {
             foreach ($fileReference->dependencies as $dependency) {
-                if (DependencyType::USE === $dependency->type) {
+                if (DependencyType::USE === $dependency->context->dependencyType) {
                     continue;
                 }
 
-                if (DependencyType::UNRESOLVED_FUNCTION_CALL === $dependency->type) {
+                if (DependencyType::UNRESOLVED_FUNCTION_CALL === $dependency->context->dependencyType) {
                     continue;
                 }
 
@@ -32,8 +32,7 @@ final class FileDependencyEmitter implements DependencyEmitterInterface
                     new Dependency(
                         $fileReference->getToken(),
                         $dependency->token,
-                        $dependency->fileOccurrence,
-                        $dependency->type
+                        $dependency->context,
                     )
                 );
             }

--- a/src/Core/Dependency/Emitter/FunctionCallDependencyEmitter.php
+++ b/src/Core/Dependency/Emitter/FunctionCallDependencyEmitter.php
@@ -34,7 +34,7 @@ final class FunctionCallDependencyEmitter implements DependencyEmitterInterface
     {
         foreach ($references as $reference) {
             foreach ($reference->dependencies as $dependency) {
-                if (DependencyType::UNRESOLVED_FUNCTION_CALL !== $dependency->type) {
+                if (DependencyType::UNRESOLVED_FUNCTION_CALL !== $dependency->context->dependencyType) {
                     continue;
                 }
 
@@ -46,7 +46,7 @@ final class FunctionCallDependencyEmitter implements DependencyEmitterInterface
 
                 $dependencyList->addDependency(
                     new Dependency(
-                        $reference->getToken(), $dependency->token, $dependency->fileOccurrence, $dependency->type
+                        $reference->getToken(), $dependency->token, $dependency->context
                     )
                 );
             }

--- a/src/Core/Dependency/Emitter/FunctionDependencyEmitter.php
+++ b/src/Core/Dependency/Emitter/FunctionDependencyEmitter.php
@@ -21,11 +21,11 @@ final class FunctionDependencyEmitter implements DependencyEmitterInterface
         foreach ($astMap->getFileReferences() as $astFileReference) {
             foreach ($astFileReference->functionReferences as $astFunctionReference) {
                 foreach ($astFunctionReference->dependencies as $dependency) {
-                    if (DependencyType::SUPERGLOBAL_VARIABLE === $dependency->type) {
+                    if (DependencyType::SUPERGLOBAL_VARIABLE === $dependency->context->dependencyType) {
                         continue;
                     }
 
-                    if (DependencyType::UNRESOLVED_FUNCTION_CALL === $dependency->type) {
+                    if (DependencyType::UNRESOLVED_FUNCTION_CALL === $dependency->context->dependencyType) {
                         continue;
                     }
 
@@ -33,8 +33,7 @@ final class FunctionDependencyEmitter implements DependencyEmitterInterface
                         new Dependency(
                             $astFunctionReference->getToken(),
                             $dependency->token,
-                            $dependency->fileOccurrence,
-                            $dependency->type
+                            $dependency->context,
                         )
                     );
                 }

--- a/src/Core/Dependency/Emitter/FunctionSuperglobalDependencyEmitter.php
+++ b/src/Core/Dependency/Emitter/FunctionSuperglobalDependencyEmitter.php
@@ -21,15 +21,14 @@ final class FunctionSuperglobalDependencyEmitter implements DependencyEmitterInt
         foreach ($astMap->getFileReferences() as $astFileReference) {
             foreach ($astFileReference->functionReferences as $astFunctionReference) {
                 foreach ($astFunctionReference->dependencies as $dependency) {
-                    if (DependencyType::SUPERGLOBAL_VARIABLE !== $dependency->type) {
+                    if (DependencyType::SUPERGLOBAL_VARIABLE !== $dependency->context->dependencyType) {
                         continue;
                     }
                     $dependencyList->addDependency(
                         new Dependency(
                             $astFunctionReference->getToken(),
                             $dependency->token,
-                            $dependency->fileOccurrence,
-                            $dependency->type
+                            $dependency->context,
                         )
                     );
                 }

--- a/src/Core/Dependency/Emitter/UsesDependencyEmitter.php
+++ b/src/Core/Dependency/Emitter/UsesDependencyEmitter.php
@@ -38,15 +38,14 @@ final class UsesDependencyEmitter implements DependencyEmitterInterface
         foreach ($astMap->getFileReferences() as $fileReference) {
             foreach ($fileReference->classLikeReferences as $astClassReference) {
                 foreach ($fileReference->dependencies as $emittedDependency) {
-                    if (DependencyType::USE === $emittedDependency->type
+                    if (DependencyType::USE === $emittedDependency->context->dependencyType
                         && $this->isFQDN($emittedDependency, $FQDNIndex)
                     ) {
                         $dependencyList->addDependency(
                             new Dependency(
                                 $astClassReference->getToken(),
                                 $emittedDependency->token,
-                                $emittedDependency->fileOccurrence,
-                                $emittedDependency->type
+                                $emittedDependency->context,
                             )
                         );
                     }

--- a/src/Core/Dependency/InheritDependency.php
+++ b/src/Core/Dependency/InheritDependency.php
@@ -4,8 +4,7 @@ declare(strict_types=1);
 
 namespace Qossmic\Deptrac\Core\Dependency;
 
-use Qossmic\Deptrac\Contract\Ast\DependencyType;
-use Qossmic\Deptrac\Contract\Ast\FileOccurrence;
+use Qossmic\Deptrac\Contract\Ast\DependencyContext;
 use Qossmic\Deptrac\Contract\Ast\TokenInterface;
 use Qossmic\Deptrac\Contract\Dependency\DependencyInterface;
 use Qossmic\Deptrac\Core\Ast\AstMap\AstInherit;
@@ -28,7 +27,7 @@ class InheritDependency implements DependencyInterface
         }
 
         $buffer[] = ['name' => $this->inheritPath->classLikeName->toString(), 'line' => $this->inheritPath->fileOccurrence->line];
-        $buffer[] = ['name' => $this->originalDependency->getDependent()->toString(), 'line' => $this->originalDependency->getFileOccurrence()->line];
+        $buffer[] = ['name' => $this->originalDependency->getDependent()->toString(), 'line' => $this->originalDependency->getContext()->fileOccurrence->line];
 
         return $buffer;
     }
@@ -38,18 +37,13 @@ class InheritDependency implements DependencyInterface
         return $this->depender;
     }
 
-    public function getFileOccurrence(): FileOccurrence
-    {
-        return $this->originalDependency->getFileOccurrence();
-    }
-
     public function getDependent(): TokenInterface
     {
         return $this->dependent;
     }
 
-    public function getType(): DependencyType
+    public function getContext(): DependencyContext
     {
-        return $this->originalDependency->getType();
+        return $this->originalDependency->getContext();
     }
 }

--- a/src/Core/Layer/Collector/AttributeCollector.php
+++ b/src/Core/Layer/Collector/AttributeCollector.php
@@ -28,7 +28,7 @@ class AttributeCollector implements CollectorInterface
         $match = $this->getSearchedSubstring($config);
 
         foreach ($reference->dependencies as $dependency) {
-            if (DependencyType::ATTRIBUTE !== $dependency->type) {
+            if (DependencyType::ATTRIBUTE !== $dependency->context->dependencyType) {
                 continue;
             }
 

--- a/src/Supportive/Console/Command/DebugDependenciesRunner.php
+++ b/src/Supportive/Console/Command/DebugDependenciesRunner.php
@@ -50,7 +50,7 @@ final class DebugDependenciesRunner
             $rule->layer
         );
 
-        $fileOccurrence = $dependency->getFileOccurrence();
+        $fileOccurrence = $dependency->getContext()->fileOccurrence;
         $message .= sprintf("\n%s:%d", $fileOccurrence->filepath, $fileOccurrence->line);
 
         return [$message];

--- a/src/Supportive/OutputFormatter/CodeclimateOutputFormatter.php
+++ b/src/Supportive/OutputFormatter/CodeclimateOutputFormatter.php
@@ -189,9 +189,9 @@ final class CodeclimateOutputFormatter implements OutputFormatterInterface
             'categories' => ['Style', 'Complexity'],
             'severity' => $severity,
             'location' => [
-                'path' => $rule->getDependency()->getFileOccurrence()->filepath,
+                'path' => $rule->getDependency()->getContext()->fileOccurrence->filepath,
                 'lines' => [
-                    'begin' => $rule->getDependency()->getFileOccurrence()->line,
+                    'begin' => $rule->getDependency()->getContext()->fileOccurrence->line,
                 ],
             ],
         ];
@@ -203,8 +203,8 @@ final class CodeclimateOutputFormatter implements OutputFormatterInterface
             $rule::class,
             $rule->getDependency()->getDepender()->toString(),
             $rule->getDependency()->getDependent()->toString(),
-            $rule->getDependency()->getFileOccurrence()->filepath,
-            $rule->getDependency()->getFileOccurrence()->line,
+            $rule->getDependency()->getContext()->fileOccurrence->filepath,
+            $rule->getDependency()->getContext()->fileOccurrence->line,
         ]));
     }
 }

--- a/src/Supportive/OutputFormatter/ConsoleOutputFormatter.php
+++ b/src/Supportive/OutputFormatter/ConsoleOutputFormatter.php
@@ -71,7 +71,7 @@ final class ConsoleOutputFormatter implements OutputFormatterInterface
                 $rule->getDependentLayer()
             )
         );
-        $this->printFileOccurrence($output, $dependency->getFileOccurrence());
+        $this->printFileOccurrence($output, $dependency->getContext()->fileOccurrence);
 
         if (count($dependency->serialize()) > 1) {
             $this->printMultilinePath($output, $dependency);
@@ -160,7 +160,7 @@ final class ConsoleOutputFormatter implements OutputFormatterInterface
                     $u->layer
                 )
             );
-            $this->printFileOccurrence($output, $dependency->getFileOccurrence());
+            $this->printFileOccurrence($output, $dependency->getContext()->fileOccurrence);
 
             if (count($dependency->serialize()) > 1) {
                 $this->printMultilinePath($output, $dependency);

--- a/src/Supportive/OutputFormatter/GithubActionsOutputFormatter.php
+++ b/src/Supportive/OutputFormatter/GithubActionsOutputFormatter.php
@@ -66,8 +66,8 @@ final class GithubActionsOutputFormatter implements OutputFormatterInterface
                 sprintf(
                     '::%s file=%s,line=%s::%s has uncovered dependency on %s (%s)',
                     $reportAsError ? 'error' : 'warning',
-                    $dependency->getFileOccurrence()->filepath,
-                    $dependency->getFileOccurrence()->line,
+                    $dependency->getContext()->fileOccurrence->filepath,
+                    $dependency->getContext()->fileOccurrence->line,
                     $dependency->getDepender()->toString(),
                     $dependency->getDependent()->toString(),
                     $u->layer
@@ -124,8 +124,8 @@ final class GithubActionsOutputFormatter implements OutputFormatterInterface
             sprintf(
                 '::%s file=%s,line=%s::%s',
                 $this->determineLogLevel($rule),
-                $dependency->getFileOccurrence()->filepath,
-                $dependency->getFileOccurrence()->line,
+                $dependency->getContext()->fileOccurrence->filepath,
+                $dependency->getContext()->fileOccurrence->line,
                 $message
             )
         );

--- a/src/Supportive/OutputFormatter/JUnitOutputFormatter.php
+++ b/src/Supportive/OutputFormatter/JUnitOutputFormatter.php
@@ -194,7 +194,7 @@ final class JUnitOutputFormatter implements OutputFormatterInterface
         $message = sprintf(
             '%s:%d must not depend on %s (%s on %s)',
             $dependency->getDepender()->toString(),
-            $dependency->getFileOccurrence()->line,
+            $dependency->getContext()->fileOccurrence->line,
             $dependency->getDependent()->toString(),
             $violation->getDependerLayer(),
             $violation->getDependentLayer()
@@ -224,7 +224,7 @@ final class JUnitOutputFormatter implements OutputFormatterInterface
         $message = sprintf(
             '%s:%d has uncovered dependency on %s (%s)',
             $dependency->getDepender()->toString(),
-            $dependency->getFileOccurrence()->line,
+            $dependency->getContext()->fileOccurrence->line,
             $dependency->getDependent()->toString(),
             $rule->layer
         );

--- a/src/Supportive/OutputFormatter/JsonOutputFormatter.php
+++ b/src/Supportive/OutputFormatter/JsonOutputFormatter.php
@@ -92,11 +92,11 @@ final class JsonOutputFormatter implements OutputFormatterInterface
      */
     private function addFailure(array &$violationsArray, Violation $violation): void
     {
-        $className = $violation->getDependency()->getFileOccurrence()->filepath;
+        $className = $violation->getDependency()->getContext()->fileOccurrence->filepath;
 
         $violationsArray[$className]['messages'][] = [
             'message' => $this->getFailureMessage($violation),
-            'line' => $violation->getDependency()->getFileOccurrence()->line,
+            'line' => $violation->getDependency()->getContext()->fileOccurrence->line,
             'type' => 'error',
         ];
     }
@@ -119,11 +119,11 @@ final class JsonOutputFormatter implements OutputFormatterInterface
      */
     private function addSkipped(array &$violationsArray, SkippedViolation $violation): void
     {
-        $className = $violation->getDependency()->getFileOccurrence()->filepath;
+        $className = $violation->getDependency()->getContext()->fileOccurrence->filepath;
 
         $violationsArray[$className]['messages'][] = [
             'message' => $this->getWarningMessage($violation),
-            'line' => $violation->getDependency()->getFileOccurrence()->line,
+            'line' => $violation->getDependency()->getContext()->fileOccurrence->line,
             'type' => 'warning',
         ];
     }
@@ -146,11 +146,11 @@ final class JsonOutputFormatter implements OutputFormatterInterface
      */
     private function addUncovered(array &$violationsArray, Uncovered $violation): void
     {
-        $className = $violation->getDependency()->getFileOccurrence()->filepath;
+        $className = $violation->getDependency()->getContext()->fileOccurrence->filepath;
 
         $violationsArray[$className]['messages'][] = [
             'message' => $this->getUncoveredMessage($violation),
-            'line' => $violation->getDependency()->getFileOccurrence()->line,
+            'line' => $violation->getDependency()->getContext()->fileOccurrence->line,
             'type' => 'warning',
         ];
     }

--- a/src/Supportive/OutputFormatter/TableOutputFormatter.php
+++ b/src/Supportive/OutputFormatter/TableOutputFormatter.php
@@ -92,7 +92,7 @@ final class TableOutputFormatter implements OutputFormatterInterface
             $message .= "\n".$this->formatMultilinePath($dependency);
         }
 
-        $fileOccurrence = $rule->getDependency()->getFileOccurrence();
+        $fileOccurrence = $rule->getDependency()->getContext()->fileOccurrence;
         $message .= sprintf("\n%s:%d", $fileOccurrence->filepath, $fileOccurrence->line);
 
         return ['<fg=yellow>Skipped</>', $message];
@@ -116,7 +116,7 @@ final class TableOutputFormatter implements OutputFormatterInterface
             $message .= "\n".$this->formatMultilinePath($dependency);
         }
 
-        $fileOccurrence = $rule->getDependency()->getFileOccurrence();
+        $fileOccurrence = $rule->getDependency()->getContext()->fileOccurrence;
         $message .= sprintf("\n%s:%d", $fileOccurrence->filepath, $fileOccurrence->line);
 
         return [sprintf('<fg=red>%s</>', $rule->ruleName()), $message];
@@ -175,7 +175,7 @@ final class TableOutputFormatter implements OutputFormatterInterface
             $message .= "\n".$this->formatMultilinePath($dependency);
         }
 
-        $fileOccurrence = $rule->getDependency()->getFileOccurrence();
+        $fileOccurrence = $rule->getDependency()->getContext()->fileOccurrence;
         $message .= sprintf("\n%s:%d", $fileOccurrence->filepath, $fileOccurrence->line);
 
         return [

--- a/src/Supportive/OutputFormatter/XMLOutputFormatter.php
+++ b/src/Supportive/OutputFormatter/XMLOutputFormatter.php
@@ -89,7 +89,7 @@ final class XMLOutputFormatter implements OutputFormatterInterface
         /** @throws void */
         $entry->appendChild($xmlDoc->createElement('ClassB', $dependency->getDependent()->toString()));
 
-        $fileOccurrence = $dependency->getFileOccurrence();
+        $fileOccurrence = $dependency->getContext()->fileOccurrence;
         /** @throws void */
         $occurrence = $xmlDoc->createElement('occurrence');
         $occurrence->setAttribute('file', $fileOccurrence->filepath);

--- a/tests/Core/Analyser/EventHandler/DependsOnInternalTokenTest.php
+++ b/tests/Core/Analyser/EventHandler/DependsOnInternalTokenTest.php
@@ -8,6 +8,7 @@ use PHPUnit\Framework\TestCase;
 use Qossmic\Deptrac\Contract\Analyser\AnalysisResult;
 use Qossmic\Deptrac\Contract\Analyser\EventHelper;
 use Qossmic\Deptrac\Contract\Analyser\ProcessEvent;
+use Qossmic\Deptrac\Contract\Ast\DependencyContext;
 use Qossmic\Deptrac\Contract\Ast\DependencyType;
 use Qossmic\Deptrac\Contract\Ast\FileOccurrence;
 use Qossmic\Deptrac\Contract\Layer\LayerProvider;
@@ -38,8 +39,8 @@ final class DependsOnInternalTokenTest extends TestCase
             new Dependency(
                 $dependerToken,
                 $dependentToken,
-                new FileOccurrence('test', 1),
-                DependencyType::STATIC_METHOD
+                new DependencyContext(new FileOccurrence('test', 1),
+                    DependencyType::STATIC_METHOD)
             ),
             new ClassLikeReference($dependerToken, ClassLikeType::TYPE_CLASS,
                 [], [], $dependerTags),

--- a/tests/Core/Ast/Parser/AnnotationReferenceExtractorTest.php
+++ b/tests/Core/Ast/Parser/AnnotationReferenceExtractorTest.php
@@ -42,48 +42,48 @@ final class AnnotationReferenceExtractorTest extends TestCase
             'Tests\Qossmic\Deptrac\Core\Ast\Parser\Fixtures\AnnotationDependencyChild',
             $annotationDependency[0]->token->toString()
         );
-        self::assertSame($filePath, $annotationDependency[0]->fileOccurrence->filepath);
-        self::assertSame(9, $annotationDependency[0]->fileOccurrence->line);
-        self::assertSame('variable', $annotationDependency[0]->type->value);
+        self::assertSame($filePath, $annotationDependency[0]->context->fileOccurrence->filepath);
+        self::assertSame(9, $annotationDependency[0]->context->fileOccurrence->line);
+        self::assertSame('variable', $annotationDependency[0]->context->dependencyType->value);
 
         self::assertSame(
             'Tests\Qossmic\Deptrac\Core\Ast\Parser\Fixtures\AnnotationDependencyChild',
             $annotationDependency[1]->token->toString()
         );
-        self::assertSame($filePath, $annotationDependency[1]->fileOccurrence->filepath);
-        self::assertSame(23, $annotationDependency[1]->fileOccurrence->line);
-        self::assertSame('variable', $annotationDependency[1]->type->value);
+        self::assertSame($filePath, $annotationDependency[1]->context->fileOccurrence->filepath);
+        self::assertSame(23, $annotationDependency[1]->context->fileOccurrence->line);
+        self::assertSame('variable', $annotationDependency[1]->context->dependencyType->value);
 
         self::assertSame(
             'Tests\Qossmic\Deptrac\Core\Ast\Parser\Fixtures\AnnotationDependencyChild',
             $annotationDependency[2]->token->toString()
         );
-        self::assertSame($filePath, $annotationDependency[2]->fileOccurrence->filepath);
-        self::assertSame(26, $annotationDependency[2]->fileOccurrence->line);
-        self::assertSame('variable', $annotationDependency[2]->type->value);
+        self::assertSame($filePath, $annotationDependency[2]->context->fileOccurrence->filepath);
+        self::assertSame(26, $annotationDependency[2]->context->fileOccurrence->line);
+        self::assertSame('variable', $annotationDependency[2]->context->dependencyType->value);
 
         self::assertSame(
             'Symfony\Component\Console\Exception\RuntimeException',
             $annotationDependency[3]->token->toString()
         );
-        self::assertSame($filePath, $annotationDependency[3]->fileOccurrence->filepath);
-        self::assertSame(29, $annotationDependency[3]->fileOccurrence->line);
-        self::assertSame('variable', $annotationDependency[3]->type->value);
+        self::assertSame($filePath, $annotationDependency[3]->context->fileOccurrence->filepath);
+        self::assertSame(29, $annotationDependency[3]->context->fileOccurrence->line);
+        self::assertSame('variable', $annotationDependency[3]->context->dependencyType->value);
 
         self::assertSame(
             'Symfony\Component\Finder\SplFileInfo',
             $annotationDependency[4]->token->toString()
         );
-        self::assertSame($filePath, $annotationDependency[4]->fileOccurrence->filepath);
-        self::assertSame(14, $annotationDependency[4]->fileOccurrence->line);
-        self::assertSame('parameter', $annotationDependency[4]->type->value);
+        self::assertSame($filePath, $annotationDependency[4]->context->fileOccurrence->filepath);
+        self::assertSame(14, $annotationDependency[4]->context->fileOccurrence->line);
+        self::assertSame('parameter', $annotationDependency[4]->context->dependencyType->value);
 
         self::assertSame(
             'Tests\Qossmic\Deptrac\Core\Ast\Parser\Fixtures\AnnotationDependencyChild',
             $annotationDependency[5]->token->toString()
         );
-        self::assertSame($filePath, $annotationDependency[5]->fileOccurrence->filepath);
-        self::assertSame(14, $annotationDependency[5]->fileOccurrence->line);
-        self::assertSame('returntype', $annotationDependency[5]->type->value);
+        self::assertSame($filePath, $annotationDependency[5]->context->fileOccurrence->filepath);
+        self::assertSame(14, $annotationDependency[5]->context->fileOccurrence->line);
+        self::assertSame('returntype', $annotationDependency[5]->context->dependencyType->value);
     }
 }

--- a/tests/Core/Ast/Parser/AnonymousClassExtractorTest.php
+++ b/tests/Core/Ast/Parser/AnonymousClassExtractorTest.php
@@ -41,16 +41,16 @@ final class AnonymousClassExtractorTest extends TestCase
             'Tests\Qossmic\Deptrac\Core\Ast\Parser\Fixtures\ClassA',
             $dependencies[0]->token->toString()
         );
-        self::assertSame($filePath, $dependencies[0]->fileOccurrence->filepath);
-        self::assertSame(19, $dependencies[0]->fileOccurrence->line);
-        self::assertSame('anonymous_class_extends', $dependencies[0]->type->value);
+        self::assertSame($filePath, $dependencies[0]->context->fileOccurrence->filepath);
+        self::assertSame(19, $dependencies[0]->context->fileOccurrence->line);
+        self::assertSame('anonymous_class_extends', $dependencies[0]->context->dependencyType->value);
 
         self::assertSame(
             'Tests\Qossmic\Deptrac\Core\Ast\Parser\Fixtures\InterfaceC',
             $dependencies[1]->token->toString()
         );
-        self::assertSame($filePath, $dependencies[1]->fileOccurrence->filepath);
-        self::assertSame(19, $dependencies[1]->fileOccurrence->line);
-        self::assertSame('anonymous_class_implements', $dependencies[1]->type->value);
+        self::assertSame($filePath, $dependencies[1]->context->fileOccurrence->filepath);
+        self::assertSame(19, $dependencies[1]->context->fileOccurrence->line);
+        self::assertSame('anonymous_class_implements', $dependencies[1]->context->dependencyType->value);
     }
 }

--- a/tests/Core/Ast/Parser/ClassConstantExtractorTest.php
+++ b/tests/Core/Ast/Parser/ClassConstantExtractorTest.php
@@ -39,8 +39,8 @@ final class ClassConstantExtractorTest extends TestCase
             'Tests\Qossmic\Deptrac\Core\Ast\Parser\Fixtures\ClassA',
             $dependencies[0]->token->toString()
         );
-        self::assertSame($filePath, $dependencies[0]->fileOccurrence->filepath);
-        self::assertSame(15, $dependencies[0]->fileOccurrence->line);
-        self::assertSame('const', $dependencies[0]->type->value);
+        self::assertSame($filePath, $dependencies[0]->context->fileOccurrence->filepath);
+        self::assertSame(15, $dependencies[0]->context->fileOccurrence->line);
+        self::assertSame('const', $dependencies[0]->context->dependencyType->value);
     }
 }

--- a/tests/Core/Ast/Parser/ClassDocBlockExtractorTest.php
+++ b/tests/Core/Ast/Parser/ClassDocBlockExtractorTest.php
@@ -44,7 +44,7 @@ final class ClassDocBlockExtractorTest extends TestCase
 
         foreach ($dependencies as $key => $dependency) {
             self::assertSame(self::EXPECTED[$key][0], $dependency->token->toString());
-            self::assertSame(self::EXPECTED[$key][1], $dependency->type);
+            self::assertSame(self::EXPECTED[$key][1], $dependency->context->dependencyType);
         }
     }
 }

--- a/tests/Core/Dependency/DependencyListTest.php
+++ b/tests/Core/Dependency/DependencyListTest.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace Tests\Qossmic\Deptrac\Core\Dependency;
 
 use PHPUnit\Framework\TestCase;
+use Qossmic\Deptrac\Contract\Ast\DependencyContext;
 use Qossmic\Deptrac\Contract\Ast\DependencyType;
 use Qossmic\Deptrac\Contract\Ast\FileOccurrence;
 use Qossmic\Deptrac\Core\Ast\AstMap\AstInherit;
@@ -23,9 +24,12 @@ final class DependencyListTest extends TestCase
         $classC = ClassLikeToken::fromFQCN('C');
 
         $dependencyResult = new DependencyList();
-        $dependencyResult->addDependency($dep1 = new Dependency($classA, $classB, new FileOccurrence('a.php', 12), DependencyType::PARAMETER));
-        $dependencyResult->addDependency($dep2 = new Dependency($classB, $classC, new FileOccurrence('b.php', 12), DependencyType::PARAMETER));
-        $dependencyResult->addDependency($dep3 = new Dependency($classA, $classC, new FileOccurrence('a.php', 12), DependencyType::PARAMETER));
+        $dependencyResult->addDependency($dep1 = new Dependency($classA, $classB, new DependencyContext(
+            new FileOccurrence('a.php', 12), DependencyType::PARAMETER)));
+        $dependencyResult->addDependency($dep2 = new Dependency($classB, $classC, new DependencyContext(
+            new FileOccurrence('b.php', 12), DependencyType::PARAMETER)));
+        $dependencyResult->addDependency($dep3 = new Dependency($classA, $classC, new DependencyContext(
+            new FileOccurrence('a.php', 12), DependencyType::PARAMETER)));
         self::assertSame([$dep1, $dep3], $dependencyResult->getDependenciesByClass($classA));
         self::assertSame([$dep2], $dependencyResult->getDependenciesByClass($classB));
         self::assertSame([], $dependencyResult->getDependenciesByClass($classC));
@@ -38,7 +42,8 @@ final class DependencyListTest extends TestCase
         $classB = ClassLikeToken::fromFQCN('B');
 
         $dependencyResult = new DependencyList();
-        $dependencyResult->addDependency($dep1 = new Dependency($classA, $classB, new FileOccurrence('a.php', 12), DependencyType::PARAMETER));
+        $dependencyResult->addDependency($dep1 = new Dependency($classA, $classB, new DependencyContext(
+            new FileOccurrence('a.php', 12), DependencyType::PARAMETER)));
         $dependencyResult->addInheritDependency($dep2 = new InheritDependency($classA, $classB, $dep1,
             new AstInherit(
                 $classB,

--- a/tests/Core/Dependency/DependencyTest.php
+++ b/tests/Core/Dependency/DependencyTest.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace Tests\Qossmic\Deptrac\Core\Dependency;
 
 use PHPUnit\Framework\TestCase;
+use Qossmic\Deptrac\Contract\Ast\DependencyContext;
 use Qossmic\Deptrac\Contract\Ast\DependencyType;
 use Qossmic\Deptrac\Contract\Ast\FileOccurrence;
 use Qossmic\Deptrac\Core\Ast\AstMap\ClassLike\ClassLikeToken;
@@ -16,11 +17,11 @@ final class DependencyTest extends TestCase
     {
         $dependency = new Dependency(
             ClassLikeToken::fromFQCN('a'),
-            ClassLikeToken::fromFQCN('b'), new FileOccurrence('/foo.php', 23), DependencyType::PARAMETER
-        );
+            ClassLikeToken::fromFQCN('b'), new DependencyContext(new FileOccurrence('/foo.php', 23), DependencyType::PARAMETER
+            ));
         self::assertSame('a', $dependency->getDepender()->toString());
-        self::assertSame('/foo.php', $dependency->getFileOccurrence()->filepath);
-        self::assertSame(23, $dependency->getFileOccurrence()->line);
+        self::assertSame('/foo.php', $dependency->getContext()->fileOccurrence->filepath);
+        self::assertSame(23, $dependency->getContext()->fileOccurrence->line);
         self::assertSame('b', $dependency->getDependent()->toString());
     }
 }

--- a/tests/Core/Dependency/Emitter/EmitterTrait.php
+++ b/tests/Core/Dependency/Emitter/EmitterTrait.php
@@ -55,7 +55,7 @@ trait EmitterTrait
             static function (DependencyInterface $d) {
                 return sprintf('%s:%d on %s',
                     $d->getDepender()->toString(),
-                    $d->getFileOccurrence()->line,
+                    $d->getContext()->fileOccurrence->line,
                     $d->getDependent()->toString()
                 );
             },

--- a/tests/Core/Dependency/InheritDependencyTest.php
+++ b/tests/Core/Dependency/InheritDependencyTest.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace Tests\Qossmic\Deptrac\Core\Dependency;
 
 use PHPUnit\Framework\TestCase;
+use Qossmic\Deptrac\Contract\Ast\DependencyContext;
 use Qossmic\Deptrac\Contract\Ast\DependencyType;
 use Qossmic\Deptrac\Contract\Ast\FileOccurrence;
 use Qossmic\Deptrac\Core\Ast\AstMap\AstInherit;
@@ -24,13 +25,14 @@ final class InheritDependencyTest extends TestCase
         $dependency = new InheritDependency(
             $classLikeNameA,
             $classLikeNameB,
-            $dep = new Dependency($classLikeNameA, $classLikeNameB, $fileOccurrence, DependencyType::PARAMETER),
+            $dep = new Dependency($classLikeNameA, $classLikeNameB, new DependencyContext(
+                $fileOccurrence, DependencyType::PARAMETER)),
             $astInherit = new AstInherit($classLikeNameB, $fileOccurrence, AstInheritType::EXTENDS)
         );
 
         self::assertSame($classLikeNameA, $dependency->getDepender());
         self::assertSame($classLikeNameB, $dependency->getDependent());
-        self::assertSame(1, $dependency->getFileOccurrence()->line);
+        self::assertSame(1, $dependency->getContext()->fileOccurrence->line);
         self::assertSame($dep, $dependency->originalDependency);
         self::assertSame($astInherit, $dependency->inheritPath);
     }

--- a/tests/Supportive/OutputFormatter/BaselineOutputFormatterTest.php
+++ b/tests/Supportive/OutputFormatter/BaselineOutputFormatterTest.php
@@ -6,6 +6,7 @@ namespace Tests\Qossmic\Deptrac\Supportive\OutputFormatter;
 
 use PHPUnit\Framework\TestCase;
 use Qossmic\Deptrac\Contract\Analyser\AnalysisResult;
+use Qossmic\Deptrac\Contract\Ast\DependencyContext;
 use Qossmic\Deptrac\Contract\Ast\DependencyType;
 use Qossmic\Deptrac\Contract\Ast\FileOccurrence;
 use Qossmic\Deptrac\Contract\OutputFormatter\OutputFormatterInput;
@@ -44,7 +45,7 @@ class BaselineOutputFormatterTest extends TestCase
                     new InheritDependency(
                         ClassLikeToken::fromFQCN('ClassA'),
                         ClassLikeToken::fromFQCN('ClassB'),
-                        new Dependency($originalA, $originalB, new FileOccurrence('originalA.php', 12), DependencyType::PARAMETER),
+                        new Dependency($originalA, $originalB, new DependencyContext(new FileOccurrence('originalA.php', 12), DependencyType::PARAMETER)),
                         (new AstInherit(
                             ClassLikeToken::fromFQCN('ClassInheritA'), new FileOccurrence('originalA.php', 3),
                             AstInheritType::EXTENDS
@@ -78,7 +79,7 @@ class BaselineOutputFormatterTest extends TestCase
         yield [
             [
                 new Violation(
-                    new Dependency($originalA, $originalB, new FileOccurrence('originalA.php', 12), DependencyType::PARAMETER),
+                    new Dependency($originalA, $originalB, new DependencyContext(new FileOccurrence('originalA.php', 12), DependencyType::PARAMETER)),
                     'LayerA',
                     'LayerB',
                     new DummyViolationCreatingRule()
@@ -95,7 +96,7 @@ class BaselineOutputFormatterTest extends TestCase
         yield [
             [
                 new SkippedViolation(
-                    new Dependency($originalA, $originalB, new FileOccurrence('originalA.php', 12), DependencyType::PARAMETER),
+                    new Dependency($originalA, $originalB, new DependencyContext(new FileOccurrence('originalA.php', 12), DependencyType::PARAMETER)),
                     'LayerA',
                     'LayerB'
                 ),
@@ -106,7 +107,7 @@ class BaselineOutputFormatterTest extends TestCase
         yield [
             [
                 new Uncovered(
-                    new Dependency($originalA, $originalB, new FileOccurrence('originalA.php', 12), DependencyType::PARAMETER),
+                    new Dependency($originalA, $originalB, new DependencyContext(new FileOccurrence('originalA.php', 12), DependencyType::PARAMETER)),
                     'LayerA'
                 ),
             ],

--- a/tests/Supportive/OutputFormatter/CodeclimateOutputFormatterTest.php
+++ b/tests/Supportive/OutputFormatter/CodeclimateOutputFormatterTest.php
@@ -7,6 +7,7 @@ namespace Tests\Qossmic\Deptrac\Supportive\OutputFormatter;
 use Exception;
 use PHPUnit\Framework\TestCase;
 use Qossmic\Deptrac\Contract\Analyser\AnalysisResult;
+use Qossmic\Deptrac\Contract\Ast\DependencyContext;
 use Qossmic\Deptrac\Contract\Ast\DependencyType;
 use Qossmic\Deptrac\Contract\Ast\FileOccurrence;
 use Qossmic\Deptrac\Contract\OutputFormatter\OutputFormatterInput;
@@ -54,7 +55,7 @@ final class CodeclimateOutputFormatterTest extends TestCase
                         ClassLikeToken::fromFQCN('ClassB'),
                         new Dependency(
                             ClassLikeToken::fromFQCN('OriginalA'),
-                            ClassLikeToken::fromFQCN('OriginalB'), new FileOccurrence('ClassA.php', 12), DependencyType::PARAMETER
+                            ClassLikeToken::fromFQCN('OriginalB'), new DependencyContext(new FileOccurrence('ClassA.php', 12), DependencyType::PARAMETER)
                         ),
                         (new AstInherit(
                             ClassLikeToken::fromFQCN('ClassInheritA'), new FileOccurrence('ClassA.php', 3),
@@ -89,7 +90,7 @@ final class CodeclimateOutputFormatterTest extends TestCase
                         ClassLikeToken::fromFQCN('ClassD'),
                         new Dependency(
                             ClassLikeToken::fromFQCN('OriginalA'),
-                            ClassLikeToken::fromFQCN('OriginalB'), new FileOccurrence('ClassC.php', 12), DependencyType::PARAMETER
+                            ClassLikeToken::fromFQCN('OriginalB'), new DependencyContext(new FileOccurrence('ClassC.php', 12), DependencyType::PARAMETER)
                         ),
                         (new AstInherit(
                             ClassLikeToken::fromFQCN('ClassInheritA'), new FileOccurrence('ClassA.php', 3),
@@ -124,7 +125,7 @@ final class CodeclimateOutputFormatterTest extends TestCase
                         ClassLikeToken::fromFQCN('ClassE'),
                         new Dependency(
                             ClassLikeToken::fromFQCN('OriginalA'),
-                            ClassLikeToken::fromFQCN('OriginalB'), new FileOccurrence('ClassC.php', 15), DependencyType::PARAMETER
+                            ClassLikeToken::fromFQCN('OriginalB'), new DependencyContext(new FileOccurrence('ClassC.php', 15), DependencyType::PARAMETER)
                         ),
                         (new AstInherit(
                             ClassLikeToken::fromFQCN('ClassInheritA'), new FileOccurrence('ClassA.php', 3),
@@ -162,7 +163,7 @@ final class CodeclimateOutputFormatterTest extends TestCase
                 new Violation(
                     new Dependency(
                         ClassLikeToken::fromFQCN('OriginalA'),
-                        ClassLikeToken::fromFQCN('OriginalB'), new FileOccurrence('ClassA.php', 12), DependencyType::PARAMETER
+                        ClassLikeToken::fromFQCN('OriginalB'), new DependencyContext(new FileOccurrence('ClassA.php', 12), DependencyType::PARAMETER)
                     ),
                     'LayerA',
                     'LayerB',
@@ -185,7 +186,7 @@ final class CodeclimateOutputFormatterTest extends TestCase
                         ClassLikeToken::fromFQCN('ClassB'),
                         new Dependency(
                             ClassLikeToken::fromFQCN('OriginalA'),
-                            ClassLikeToken::fromFQCN('OriginalB'), new FileOccurrence('ClassA.php', 12), DependencyType::PARAMETER
+                            ClassLikeToken::fromFQCN('OriginalB'), new DependencyContext(new FileOccurrence('ClassA.php', 12), DependencyType::PARAMETER)
                         ),
                         (new AstInherit(
                             ClassLikeToken::fromFQCN('ClassInheritA'), new FileOccurrence('ClassA.php', 3),
@@ -219,7 +220,7 @@ final class CodeclimateOutputFormatterTest extends TestCase
                         ClassLikeToken::fromFQCN('ClassD'),
                         new Dependency(
                             ClassLikeToken::fromFQCN('OriginalA'),
-                            ClassLikeToken::fromFQCN('OriginalB'), new FileOccurrence('ClassC.php', 12), DependencyType::PARAMETER
+                            ClassLikeToken::fromFQCN('OriginalB'), new DependencyContext(new FileOccurrence('ClassC.php', 12), DependencyType::PARAMETER)
                         ),
                         (new AstInherit(
                             ClassLikeToken::fromFQCN('ClassInheritA'), new FileOccurrence('ClassA.php', 3),
@@ -259,7 +260,7 @@ final class CodeclimateOutputFormatterTest extends TestCase
                     ClassLikeToken::fromFQCN('ClassB'),
                     new Dependency(
                         ClassLikeToken::fromFQCN('OriginalA'),
-                        ClassLikeToken::fromFQCN('OriginalB'), new FileOccurrence('ClassA.php', 12), DependencyType::PARAMETER
+                        ClassLikeToken::fromFQCN('OriginalB'), new DependencyContext(new FileOccurrence('ClassA.php', 12), DependencyType::PARAMETER)
                     ),
                     (new AstInherit(
                         ClassLikeToken::fromFQCN('ClassInheritA'), new FileOccurrence('ClassA.php', 3),
@@ -291,7 +292,7 @@ final class CodeclimateOutputFormatterTest extends TestCase
                     ClassLikeToken::fromFQCN('ClassB'),
                     new Dependency(
                         ClassLikeToken::fromFQCN('OriginalA'),
-                        ClassLikeToken::fromFQCN('OriginalB'), new FileOccurrence('ClassA.php', 15), DependencyType::PARAMETER
+                        ClassLikeToken::fromFQCN('OriginalB'), new DependencyContext(new FileOccurrence('ClassA.php', 15), DependencyType::PARAMETER)
                     ),
                     (new AstInherit(
                         ClassLikeToken::fromFQCN('ClassInheritA'), new FileOccurrence('ClassA.php', 3),
@@ -322,7 +323,7 @@ final class CodeclimateOutputFormatterTest extends TestCase
                     ClassLikeToken::fromFQCN('ClassD'),
                     new Dependency(
                         ClassLikeToken::fromFQCN('OriginalA'),
-                        ClassLikeToken::fromFQCN('OriginalB'), new FileOccurrence('ClassC.php', 12), DependencyType::PARAMETER
+                        ClassLikeToken::fromFQCN('OriginalB'), new DependencyContext(new FileOccurrence('ClassC.php', 12), DependencyType::PARAMETER)
                     ),
                     (new AstInherit(
                         ClassLikeToken::fromFQCN('ClassInheritA'), new FileOccurrence('ClassA.php', 3),
@@ -350,7 +351,7 @@ final class CodeclimateOutputFormatterTest extends TestCase
             new Uncovered(
                 new Dependency(
                     ClassLikeToken::fromFQCN('OriginalA'),
-                    ClassLikeToken::fromFQCN('OriginalB'), new FileOccurrence('OriginalA.php', 12), DependencyType::PARAMETER
+                    ClassLikeToken::fromFQCN('OriginalB'), new DependencyContext(new FileOccurrence('OriginalA.php', 12), DependencyType::PARAMETER)
                 ),
                 'LayerA'
             ),
@@ -462,7 +463,7 @@ final class CodeclimateOutputFormatterTest extends TestCase
         $violation = new Violation(
             new Dependency(
                 ClassLikeToken::fromFQCN('OriginalA'),
-                ClassLikeToken::fromFQCN('OriginalB'.$malformedCharacters), new FileOccurrence('ClassA.php', 12), DependencyType::PARAMETER
+                ClassLikeToken::fromFQCN('OriginalB'.$malformedCharacters), new DependencyContext(new FileOccurrence('ClassA.php', 12), DependencyType::PARAMETER)
             ),
             'LayerA',
             'LayerB',

--- a/tests/Supportive/OutputFormatter/ConsoleOutputFormatterTest.php
+++ b/tests/Supportive/OutputFormatter/ConsoleOutputFormatterTest.php
@@ -6,6 +6,7 @@ namespace Tests\Qossmic\Deptrac\Supportive\OutputFormatter;
 
 use PHPUnit\Framework\TestCase;
 use Qossmic\Deptrac\Contract\Analyser\AnalysisResult;
+use Qossmic\Deptrac\Contract\Ast\DependencyContext;
 use Qossmic\Deptrac\Contract\Ast\DependencyType;
 use Qossmic\Deptrac\Contract\Ast\FileOccurrence;
 use Qossmic\Deptrac\Contract\OutputFormatter\OutputFormatterInput;
@@ -46,7 +47,7 @@ final class ConsoleOutputFormatterTest extends TestCase
                     new InheritDependency(
                         ClassLikeToken::fromFQCN('ClassA'),
                         ClassLikeToken::fromFQCN('ClassB'),
-                        new Dependency($originalA, $originalB, new FileOccurrence('originalA.php', 12), DependencyType::PARAMETER),
+                        new Dependency($originalA, $originalB, new DependencyContext(new FileOccurrence('originalA.php', 12), DependencyType::PARAMETER)),
                         (new AstInherit(
                             ClassLikeToken::fromFQCN('ClassInheritA'), new FileOccurrence('originalA.php', 3),
                             AstInheritType::EXTENDS
@@ -98,7 +99,7 @@ final class ConsoleOutputFormatterTest extends TestCase
         yield [
             [
                 new Violation(
-                    new Dependency($originalA, $originalB, new FileOccurrence('originalA.php', 12), DependencyType::PARAMETER),
+                    new Dependency($originalA, $originalB, new DependencyContext(new FileOccurrence('originalA.php', 12), DependencyType::PARAMETER)),
                     'LayerA',
                     'LayerB',
                     new DummyViolationCreatingRule()
@@ -139,7 +140,7 @@ final class ConsoleOutputFormatterTest extends TestCase
         yield [
             [
                 new SkippedViolation(
-                    new Dependency($originalA, $originalB, new FileOccurrence('originalA.php', 12), DependencyType::PARAMETER),
+                    new Dependency($originalA, $originalB, new DependencyContext(new FileOccurrence('originalA.php', 12), DependencyType::PARAMETER)),
                     'LayerA',
                     'LayerB'
                 ),
@@ -162,7 +163,7 @@ final class ConsoleOutputFormatterTest extends TestCase
         yield [
             [
                 new Uncovered(
-                    new Dependency($originalA, $originalB, new FileOccurrence('originalA.php', 12), DependencyType::PARAMETER),
+                    new Dependency($originalA, $originalB, new DependencyContext(new FileOccurrence('originalA.php', 12), DependencyType::PARAMETER)),
                     'LayerA'
                 ),
             ],
@@ -245,7 +246,7 @@ final class ConsoleOutputFormatterTest extends TestCase
 
         $analysisResult = new AnalysisResult();
         $analysisResult->addRule(new SkippedViolation(
-            new Dependency($originalA, $originalB, new FileOccurrence('originalA.php', 12), DependencyType::PARAMETER),
+            new Dependency($originalA, $originalB, new DependencyContext(new FileOccurrence('originalA.php', 12), DependencyType::PARAMETER)),
             'LayerA',
             'LayerB'
         ));

--- a/tests/Supportive/OutputFormatter/GithubActionsOutputFormatterTest.php
+++ b/tests/Supportive/OutputFormatter/GithubActionsOutputFormatterTest.php
@@ -6,6 +6,7 @@ namespace Tests\Qossmic\Deptrac\Supportive\OutputFormatter;
 
 use PHPUnit\Framework\TestCase;
 use Qossmic\Deptrac\Contract\Analyser\AnalysisResult;
+use Qossmic\Deptrac\Contract\Ast\DependencyContext;
 use Qossmic\Deptrac\Contract\Ast\DependencyType;
 use Qossmic\Deptrac\Contract\Ast\FileOccurrence;
 use Qossmic\Deptrac\Contract\OutputFormatter\OutputFormatterInput;
@@ -86,7 +87,7 @@ final class GithubActionsOutputFormatterTest extends TestCase
         yield 'Simple Violation' => [
             'violations' => [
                 new Violation(
-                    new Dependency($originalA, $originalB, $originalAOccurrence, DependencyType::PARAMETER),
+                    new Dependency($originalA, $originalB, new DependencyContext($originalAOccurrence, DependencyType::PARAMETER)),
                     'LayerA',
                     'LayerB',
                     new DummyViolationCreatingRule()
@@ -100,7 +101,7 @@ final class GithubActionsOutputFormatterTest extends TestCase
         yield 'Skipped Violation' => [
             'violations' => [
                 new SkippedViolation(
-                    new Dependency($originalA, $originalB, $originalAOccurrence, DependencyType::PARAMETER),
+                    new Dependency($originalA, $originalB, new DependencyContext($originalAOccurrence, DependencyType::PARAMETER)),
                     'LayerA',
                     'LayerB'
                 ),
@@ -113,7 +114,7 @@ final class GithubActionsOutputFormatterTest extends TestCase
         yield 'Uncovered Dependency' => [
             'violations' => [
                 new Uncovered(
-                    new Dependency($originalA, $originalB, $originalAOccurrence, DependencyType::PARAMETER),
+                    new Dependency($originalA, $originalB, new DependencyContext($originalAOccurrence, DependencyType::PARAMETER)),
                     'LayerA'
                 ),
             ],
@@ -128,7 +129,7 @@ final class GithubActionsOutputFormatterTest extends TestCase
                     new InheritDependency(
                         ClassLikeToken::fromFQCN('ClassA'),
                         ClassLikeToken::fromFQCN('ClassB'),
-                        new Dependency($originalA, $originalB, new FileOccurrence('originalA.php', 12), DependencyType::PARAMETER),
+                        new Dependency($originalA, $originalB, new DependencyContext(new FileOccurrence('originalA.php', 12), DependencyType::PARAMETER)),
                         (new AstInherit(
                             ClassLikeToken::fromFQCN('ClassInheritA'), new FileOccurrence('originalA.php', 3),
                             AstInheritType::EXTENDS
@@ -187,7 +188,7 @@ final class GithubActionsOutputFormatterTest extends TestCase
         $analysisResult = new AnalysisResult();
         $analysisResult->addRule(
             new SkippedViolation(
-                new Dependency($originalA, $originalB, $originalAOccurrence, DependencyType::PARAMETER),
+                new Dependency($originalA, $originalB, new DependencyContext($originalAOccurrence, DependencyType::PARAMETER)),
                 'LayerA',
                 'LayerB'
             )
@@ -219,7 +220,7 @@ final class GithubActionsOutputFormatterTest extends TestCase
         $analysisResult = new AnalysisResult();
         $analysisResult->addRule(
             new Uncovered(
-                new Dependency($originalA, $originalB, $originalAOccurrence, DependencyType::PARAMETER),
+                new Dependency($originalA, $originalB, new DependencyContext($originalAOccurrence, DependencyType::PARAMETER)),
                 'LayerA'
             )
         );

--- a/tests/Supportive/OutputFormatter/GraphVizDotOutputFormatterTest.php
+++ b/tests/Supportive/OutputFormatter/GraphVizDotOutputFormatterTest.php
@@ -6,6 +6,7 @@ namespace Tests\Qossmic\Deptrac\Supportive\OutputFormatter;
 
 use PHPUnit\Framework\TestCase;
 use Qossmic\Deptrac\Contract\Analyser\AnalysisResult;
+use Qossmic\Deptrac\Contract\Ast\DependencyContext;
 use Qossmic\Deptrac\Contract\Ast\DependencyType;
 use Qossmic\Deptrac\Contract\Ast\FileOccurrence;
 use Qossmic\Deptrac\Contract\OutputFormatter\OutputFormatterInput;
@@ -37,13 +38,13 @@ final class GraphVizDotOutputFormatterTest extends TestCase
         $classA = ClassLikeToken::fromFQCN('ClassA');
 
         $analysisResult = new AnalysisResult();
-        $analysisResult->addRule(new Violation(new Dependency($classA, ClassLikeToken::fromFQCN('ClassB'), $fileOccurrenceA, DependencyType::PARAMETER), 'LayerA', 'LayerB', new DummyViolationCreatingRule()));
-        $analysisResult->addRule(new Violation(new Dependency($classA, ClassLikeToken::fromFQCN('ClassHidden'), $fileOccurrenceA, DependencyType::PARAMETER), 'LayerA', 'LayerHidden', new DummyViolationCreatingRule()));
+        $analysisResult->addRule(new Violation(new Dependency($classA, ClassLikeToken::fromFQCN('ClassB'), new DependencyContext($fileOccurrenceA, DependencyType::PARAMETER)), 'LayerA', 'LayerB', new DummyViolationCreatingRule()));
+        $analysisResult->addRule(new Violation(new Dependency($classA, ClassLikeToken::fromFQCN('ClassHidden'), new DependencyContext($fileOccurrenceA, DependencyType::PARAMETER)), 'LayerA', 'LayerHidden', new DummyViolationCreatingRule()));
         $analysisResult->addRule(new Violation(new Dependency(ClassLikeToken::fromFQCN('ClassAB'), ClassLikeToken::fromFQCN('ClassBA'),
-            new FileOccurrence('classAB.php', 1), DependencyType::PARAMETER
+            new DependencyContext(new FileOccurrence('classAB.php', 1), DependencyType::PARAMETER)
         ), 'LayerA', 'LayerB', new DummyViolationCreatingRule()));
-        $analysisResult->addRule(new Allowed(new Dependency($classA, ClassLikeToken::fromFQCN('ClassC'), $fileOccurrenceA, DependencyType::PARAMETER), 'LayerA', 'LayerC'));
-        $analysisResult->addRule(new Uncovered(new Dependency($classA, ClassLikeToken::fromFQCN('ClassD'), $fileOccurrenceA, DependencyType::PARAMETER), 'LayerC'));
+        $analysisResult->addRule(new Allowed(new Dependency($classA, ClassLikeToken::fromFQCN('ClassC'), new DependencyContext($fileOccurrenceA, DependencyType::PARAMETER)), 'LayerA', 'LayerC'));
+        $analysisResult->addRule(new Uncovered(new Dependency($classA, ClassLikeToken::fromFQCN('ClassD'), new DependencyContext($fileOccurrenceA, DependencyType::PARAMETER)), 'LayerC'));
 
         $bufferedOutput = new BufferedOutput();
         $input = new OutputFormatterInput(
@@ -78,7 +79,7 @@ final class GraphVizDotOutputFormatterTest extends TestCase
 
         $dependency = new Dependency(
             ClassLikeToken::fromFQCN('ClassA'),
-            ClassLikeToken::fromFQCN('ClassC'), new FileOccurrence('classA.php', 0), DependencyType::PARAMETER
+            ClassLikeToken::fromFQCN('ClassC'), new DependencyContext(new FileOccurrence('classA.php', 0), DependencyType::PARAMETER)
         );
 
         $analysisResult = new AnalysisResult();
@@ -127,7 +128,7 @@ final class GraphVizDotOutputFormatterTest extends TestCase
 
         $dependency = new Dependency(
             ClassLikeToken::fromFQCN('ClassA'),
-            ClassLikeToken::fromFQCN('ClassC'), new FileOccurrence('classA.php', 0), DependencyType::PARAMETER
+            ClassLikeToken::fromFQCN('ClassC'), new DependencyContext(new FileOccurrence('classA.php', 0), DependencyType::PARAMETER)
         );
 
         $analysisResult = new AnalysisResult();

--- a/tests/Supportive/OutputFormatter/JUnitOutputFormatterTest.php
+++ b/tests/Supportive/OutputFormatter/JUnitOutputFormatterTest.php
@@ -6,6 +6,7 @@ namespace Tests\Qossmic\Deptrac\Supportive\OutputFormatter;
 
 use PHPUnit\Framework\TestCase;
 use Qossmic\Deptrac\Contract\Analyser\AnalysisResult;
+use Qossmic\Deptrac\Contract\Ast\DependencyContext;
 use Qossmic\Deptrac\Contract\Ast\DependencyType;
 use Qossmic\Deptrac\Contract\Ast\FileOccurrence;
 use Qossmic\Deptrac\Contract\OutputFormatter\OutputFormatterInput;
@@ -57,7 +58,7 @@ final class JUnitOutputFormatterTest extends TestCase
                     new InheritDependency(
                         ClassLikeToken::fromFQCN('ClassA'),
                         ClassLikeToken::fromFQCN('ClassB'),
-                        new Dependency($originalA, $originalB, new FileOccurrence('foo.php', 12), DependencyType::PARAMETER),
+                        new Dependency($originalA, $originalB, new DependencyContext(new FileOccurrence('foo.php', 12), DependencyType::PARAMETER)),
                         (new AstInherit(
                             $classInheritA, new FileOccurrence('foo.php', 3),
                             AstInheritType::EXTENDS
@@ -87,7 +88,7 @@ final class JUnitOutputFormatterTest extends TestCase
         yield [
             [
                 new Violation(
-                    new Dependency($originalA, $originalB, new FileOccurrence('foo.php', 12), DependencyType::PARAMETER),
+                    new Dependency($originalA, $originalB, new DependencyContext(new FileOccurrence('foo.php', 12), DependencyType::PARAMETER)),
                     'LayerA',
                     'LayerB',
                     new DummyViolationCreatingRule()
@@ -107,7 +108,7 @@ final class JUnitOutputFormatterTest extends TestCase
                     new InheritDependency(
                         ClassLikeToken::fromFQCN('ClassA'),
                         ClassLikeToken::fromFQCN('ClassB'),
-                        new Dependency($originalA, $originalB, new FileOccurrence('foo.php', 12), DependencyType::PARAMETER),
+                        new Dependency($originalA, $originalB, new DependencyContext(new FileOccurrence('foo.php', 12), DependencyType::PARAMETER)),
                         (new AstInherit(
                             $classInheritA, new FileOccurrence('foo.php', 3),
                             AstInheritType::EXTENDS
@@ -133,7 +134,7 @@ final class JUnitOutputFormatterTest extends TestCase
                     new InheritDependency(
                         ClassLikeToken::fromFQCN('ClassC'),
                         ClassLikeToken::fromFQCN('ClassD'),
-                        new Dependency($originalA, $originalB, new FileOccurrence('foo.php', 12), DependencyType::PARAMETER),
+                        new Dependency($originalA, $originalB, new DependencyContext(new FileOccurrence('foo.php', 12), DependencyType::PARAMETER)),
                         (new AstInherit(
                             $classInheritA, new FileOccurrence('foo.php', 3),
                             AstInheritType::EXTENDS

--- a/tests/Supportive/OutputFormatter/JsonOutputFormatterTest.php
+++ b/tests/Supportive/OutputFormatter/JsonOutputFormatterTest.php
@@ -7,6 +7,7 @@ namespace Tests\Qossmic\Deptrac\Supportive\OutputFormatter;
 use Exception;
 use PHPUnit\Framework\TestCase;
 use Qossmic\Deptrac\Contract\Analyser\AnalysisResult;
+use Qossmic\Deptrac\Contract\Ast\DependencyContext;
 use Qossmic\Deptrac\Contract\Ast\DependencyType;
 use Qossmic\Deptrac\Contract\Ast\FileOccurrence;
 use Qossmic\Deptrac\Contract\OutputFormatter\OutputFormatterInput;
@@ -53,7 +54,7 @@ final class JsonOutputFormatterTest extends TestCase
                         ClassLikeToken::fromFQCN('ClassB'),
                         new Dependency(
                             ClassLikeToken::fromFQCN('OriginalA'),
-                            ClassLikeToken::fromFQCN('OriginalB'), new FileOccurrence('ClassA.php', 12), DependencyType::PARAMETER
+                            ClassLikeToken::fromFQCN('OriginalB'), new DependencyContext(new FileOccurrence('ClassA.php', 12), DependencyType::PARAMETER)
                         ),
                         (new AstInherit(
                             ClassLikeToken::fromFQCN('ClassInheritA'), new FileOccurrence('ClassA.php', 3),
@@ -88,7 +89,7 @@ final class JsonOutputFormatterTest extends TestCase
                         ClassLikeToken::fromFQCN('ClassD'),
                         new Dependency(
                             ClassLikeToken::fromFQCN('OriginalA'),
-                            ClassLikeToken::fromFQCN('OriginalB'), new FileOccurrence('ClassC.php', 12), DependencyType::PARAMETER
+                            ClassLikeToken::fromFQCN('OriginalB'), new DependencyContext(new FileOccurrence('ClassC.php', 12), DependencyType::PARAMETER)
                         ),
                         (new AstInherit(
                             ClassLikeToken::fromFQCN('ClassInheritA'), new FileOccurrence('ClassA.php', 3),
@@ -123,7 +124,7 @@ final class JsonOutputFormatterTest extends TestCase
                         ClassLikeToken::fromFQCN('ClassE'),
                         new Dependency(
                             ClassLikeToken::fromFQCN('OriginalA'),
-                            ClassLikeToken::fromFQCN('OriginalB'), new FileOccurrence('ClassC.php', 15), DependencyType::PARAMETER
+                            ClassLikeToken::fromFQCN('OriginalB'), new DependencyContext(new FileOccurrence('ClassC.php', 15), DependencyType::PARAMETER)
                         ),
                         (new AstInherit(
                             ClassLikeToken::fromFQCN('ClassInheritA'), new FileOccurrence('ClassA.php', 3),
@@ -161,7 +162,7 @@ final class JsonOutputFormatterTest extends TestCase
                 new Violation(
                     new Dependency(
                         ClassLikeToken::fromFQCN('OriginalA'),
-                        ClassLikeToken::fromFQCN('OriginalB'), new FileOccurrence('ClassA.php', 12), DependencyType::PARAMETER
+                        ClassLikeToken::fromFQCN('OriginalB'), new DependencyContext(new FileOccurrence('ClassA.php', 12), DependencyType::PARAMETER)
                     ),
                     'LayerA',
                     'LayerB',
@@ -184,7 +185,7 @@ final class JsonOutputFormatterTest extends TestCase
                         ClassLikeToken::fromFQCN('ClassB'),
                         new Dependency(
                             ClassLikeToken::fromFQCN('OriginalA'),
-                            ClassLikeToken::fromFQCN('OriginalB'), new FileOccurrence('ClassA.php', 12), DependencyType::PARAMETER
+                            ClassLikeToken::fromFQCN('OriginalB'), new DependencyContext(new FileOccurrence('ClassA.php', 12), DependencyType::PARAMETER)
                         ),
                         (new AstInherit(
                             ClassLikeToken::fromFQCN('ClassInheritA'), new FileOccurrence('ClassA.php', 3),
@@ -218,7 +219,7 @@ final class JsonOutputFormatterTest extends TestCase
                         ClassLikeToken::fromFQCN('ClassD'),
                         new Dependency(
                             ClassLikeToken::fromFQCN('OriginalA'),
-                            ClassLikeToken::fromFQCN('OriginalB'), new FileOccurrence('ClassC.php', 12), DependencyType::PARAMETER
+                            ClassLikeToken::fromFQCN('OriginalB'), new DependencyContext(new FileOccurrence('ClassC.php', 12), DependencyType::PARAMETER)
                         ),
                         (new AstInherit(
                             ClassLikeToken::fromFQCN('ClassInheritA'), new FileOccurrence('ClassA.php', 3),
@@ -259,7 +260,7 @@ final class JsonOutputFormatterTest extends TestCase
                         ClassLikeToken::fromFQCN('ClassB'),
                         new Dependency(
                             ClassLikeToken::fromFQCN('OriginalA'),
-                            ClassLikeToken::fromFQCN('OriginalB'), new FileOccurrence('ClassA.php', 12), DependencyType::PARAMETER
+                            ClassLikeToken::fromFQCN('OriginalB'), new DependencyContext(new FileOccurrence('ClassA.php', 12), DependencyType::PARAMETER)
                         ),
                         (new AstInherit(
                             ClassLikeToken::fromFQCN('ClassInheritA'), new FileOccurrence('ClassA.php', 3),
@@ -294,7 +295,7 @@ final class JsonOutputFormatterTest extends TestCase
                         ClassLikeToken::fromFQCN('ClassB'),
                         new Dependency(
                             ClassLikeToken::fromFQCN('OriginalA'),
-                            ClassLikeToken::fromFQCN('OriginalB'), new FileOccurrence('ClassA.php', 15), DependencyType::PARAMETER
+                            ClassLikeToken::fromFQCN('OriginalB'), new DependencyContext(new FileOccurrence('ClassA.php', 15), DependencyType::PARAMETER)
                         ),
                         (new AstInherit(
                             ClassLikeToken::fromFQCN('ClassInheritA'), new FileOccurrence('ClassA.php', 3),
@@ -328,7 +329,7 @@ final class JsonOutputFormatterTest extends TestCase
                         ClassLikeToken::fromFQCN('ClassD'),
                         new Dependency(
                             ClassLikeToken::fromFQCN('OriginalA'),
-                            ClassLikeToken::fromFQCN('OriginalB'), new FileOccurrence('ClassC.php', 12), DependencyType::PARAMETER
+                            ClassLikeToken::fromFQCN('OriginalB'), new DependencyContext(new FileOccurrence('ClassC.php', 12), DependencyType::PARAMETER)
                         ),
                         (new AstInherit(
                             ClassLikeToken::fromFQCN('ClassInheritA'), new FileOccurrence('ClassA.php', 3),
@@ -359,7 +360,7 @@ final class JsonOutputFormatterTest extends TestCase
                 new Uncovered(
                     new Dependency(
                         ClassLikeToken::fromFQCN('OriginalA'),
-                        ClassLikeToken::fromFQCN('OriginalB'), new FileOccurrence('OriginalA.php', 12), DependencyType::PARAMETER
+                        ClassLikeToken::fromFQCN('OriginalB'), new DependencyContext(new FileOccurrence('OriginalA.php', 12), DependencyType::PARAMETER)
                     ),
                     'LayerA'
                 ),
@@ -447,7 +448,7 @@ final class JsonOutputFormatterTest extends TestCase
         $violation = new Violation(
             new Dependency(
                 ClassLikeToken::fromFQCN('OriginalA'),
-                ClassLikeToken::fromFQCN('OriginalB'.$malformedCharacters), new FileOccurrence('ClassA.php', 12), DependencyType::PARAMETER
+                ClassLikeToken::fromFQCN('OriginalB'.$malformedCharacters), new DependencyContext(new FileOccurrence('ClassA.php', 12), DependencyType::PARAMETER)
             ),
             'LayerA',
             'LayerB',

--- a/tests/Supportive/OutputFormatter/TableOutputFormatterTest.php
+++ b/tests/Supportive/OutputFormatter/TableOutputFormatterTest.php
@@ -6,6 +6,7 @@ namespace Tests\Qossmic\Deptrac\Supportive\OutputFormatter;
 
 use PHPUnit\Framework\TestCase;
 use Qossmic\Deptrac\Contract\Analyser\AnalysisResult;
+use Qossmic\Deptrac\Contract\Ast\DependencyContext;
 use Qossmic\Deptrac\Contract\Ast\DependencyType;
 use Qossmic\Deptrac\Contract\Ast\FileOccurrence;
 use Qossmic\Deptrac\Contract\OutputFormatter\OutputFormatterInput;
@@ -48,7 +49,7 @@ class TableOutputFormatterTest extends TestCase
                     new InheritDependency(
                         ClassLikeToken::fromFQCN('ClassA'),
                         ClassLikeToken::fromFQCN('ClassB'),
-                        new Dependency($originalA, $originalB, new FileOccurrence('originalA.php', 12), DependencyType::PARAMETER),
+                        new Dependency($originalA, $originalB, new DependencyContext(new FileOccurrence('originalA.php', 12), DependencyType::PARAMETER)),
                         (new AstInherit(
                             ClassLikeToken::fromFQCN('ClassInheritA'), new FileOccurrence('originalA.php', 3),
                             AstInheritType::EXTENDS
@@ -111,7 +112,7 @@ class TableOutputFormatterTest extends TestCase
         yield [
             [
                 new Violation(
-                    new Dependency($originalA, $originalB, new FileOccurrence('originalA.php', 12), DependencyType::PARAMETER),
+                    new Dependency($originalA, $originalB, new DependencyContext(new FileOccurrence('originalA.php', 12), DependencyType::PARAMETER)),
                     'LayerA',
                     'LayerB',
                     new DummyViolationCreatingRule()
@@ -164,7 +165,7 @@ class TableOutputFormatterTest extends TestCase
         yield 'skipped violations' => [
             [
                 new SkippedViolation(
-                    new Dependency($originalA, $originalB, new FileOccurrence('originalA.php', 12), DependencyType::PARAMETER),
+                    new Dependency($originalA, $originalB, new DependencyContext(new FileOccurrence('originalA.php', 12), DependencyType::PARAMETER)),
                     'LayerA',
                     'LayerB'
                 ),
@@ -196,7 +197,7 @@ class TableOutputFormatterTest extends TestCase
         yield 'skipped violations without reporting' => [
             [
                 new SkippedViolation(
-                    new Dependency($originalA, $originalB, new FileOccurrence('originalA.php', 12), DependencyType::PARAMETER),
+                    new Dependency($originalA, $originalB, new DependencyContext(new FileOccurrence('originalA.php', 12), DependencyType::PARAMETER)),
                     'LayerA',
                     'LayerB'
                 ),
@@ -223,7 +224,7 @@ class TableOutputFormatterTest extends TestCase
         yield 'uncovered' => [
             'rules' => [
                 new Uncovered(
-                    new Dependency($originalA, $originalB, new FileOccurrence('originalA.php', 12), DependencyType::PARAMETER),
+                    new Dependency($originalA, $originalB, new DependencyContext(new FileOccurrence('originalA.php', 12), DependencyType::PARAMETER)),
                     'LayerA'
                 ),
             ],
@@ -254,7 +255,7 @@ class TableOutputFormatterTest extends TestCase
         yield 'uncovered without reporting' => [
             'rules' => [
                 new Uncovered(
-                    new Dependency($originalA, $originalB, new FileOccurrence('originalA.php', 12), DependencyType::PARAMETER),
+                    new Dependency($originalA, $originalB, new DependencyContext(new FileOccurrence('originalA.php', 12), DependencyType::PARAMETER)),
                     'LayerA'
                 ),
             ],

--- a/tests/Supportive/OutputFormatter/XMLOutputFormatterTest.php
+++ b/tests/Supportive/OutputFormatter/XMLOutputFormatterTest.php
@@ -6,6 +6,7 @@ namespace Tests\Qossmic\Deptrac\Supportive\OutputFormatter;
 
 use PHPUnit\Framework\TestCase;
 use Qossmic\Deptrac\Contract\Analyser\AnalysisResult;
+use Qossmic\Deptrac\Contract\Ast\DependencyContext;
 use Qossmic\Deptrac\Contract\Ast\DependencyType;
 use Qossmic\Deptrac\Contract\Ast\FileOccurrence;
 use Qossmic\Deptrac\Contract\OutputFormatter\OutputFormatterInput;
@@ -50,7 +51,7 @@ final class XMLOutputFormatterTest extends TestCase
                         ClassLikeToken::fromFQCN('ClassA'),
                         ClassLikeToken::fromFQCN('ClassB'),
                         new Dependency(ClassLikeToken::fromFQCN('OriginalA'), ClassLikeToken::fromFQCN('OriginalB'),
-                            new FileOccurrence('ClassA.php', 12), DependencyType::PARAMETER
+                            new DependencyContext(new FileOccurrence('ClassA.php', 12), DependencyType::PARAMETER)
                         ),
                         (new AstInherit(
                             ClassLikeToken::fromFQCN('ClassInheritA'), new FileOccurrence('ClassA.php', 3),
@@ -85,7 +86,7 @@ final class XMLOutputFormatterTest extends TestCase
             [
                 new Violation(
                     new Dependency(ClassLikeToken::fromFQCN('OriginalA'), ClassLikeToken::fromFQCN('OriginalB'),
-                        new FileOccurrence('ClassA.php', 12), DependencyType::PARAMETER
+                        new DependencyContext(new FileOccurrence('ClassA.php', 12), DependencyType::PARAMETER)
                     ),
                     'LayerA',
                     'LayerB',
@@ -107,7 +108,7 @@ final class XMLOutputFormatterTest extends TestCase
                         ClassLikeToken::fromFQCN('ClassA'),
                         ClassLikeToken::fromFQCN('ClassB'),
                         new Dependency(ClassLikeToken::fromFQCN('OriginalA'), ClassLikeToken::fromFQCN('OriginalB'),
-                            new FileOccurrence('ClassA.php', 12), DependencyType::PARAMETER
+                            new DependencyContext(new FileOccurrence('ClassA.php', 12), DependencyType::PARAMETER)
                         ),
                         (new AstInherit(
                             ClassLikeToken::fromFQCN('ClassInheritA'), new FileOccurrence('ClassA.php', 3),
@@ -138,7 +139,7 @@ final class XMLOutputFormatterTest extends TestCase
                         ClassLikeToken::fromFQCN('ClassC'),
                         ClassLikeToken::fromFQCN('ClassD'),
                         new Dependency(ClassLikeToken::fromFQCN('OriginalA'), ClassLikeToken::fromFQCN('OriginalB'),
-                            new FileOccurrence('ClassA.php', 12), DependencyType::PARAMETER
+                            new DependencyContext(new FileOccurrence('ClassA.php', 12), DependencyType::PARAMETER)
                         ),
                         (new AstInherit(
                             ClassLikeToken::fromFQCN('ClassInheritA'), new FileOccurrence('ClassA.php', 3),


### PR DESCRIPTION
to use `DependencyContext` instead of `FileOccurence` and `DependencyType`, so that we do not add a new method to the interface and constructor parameters every time we want to add a piece of information about the dependency.

Created to enable https://github.com/qossmic/deptrac/pull/1359

BC break: Yes