### PR TITLE
ConsoleFormatter: output 'file:line' to allow jump-to-line in IDEs

### DIFF
--- a/src/Supportive/OutputFormatter/ConsoleOutputFormatter.php
+++ b/src/Supportive/OutputFormatter/ConsoleOutputFormatter.php
@@ -170,7 +170,7 @@ final class ConsoleOutputFormatter implements OutputFormatterInterface
 
     private function printFileOccurrence(OutputInterface $output, FileOccurrence $fileOccurrence): void
     {
-        $output->writeLineFormatted($fileOccurrence->filepath.'::'.$fileOccurrence->line);
+        $output->writeLineFormatted($fileOccurrence->filepath.':'.$fileOccurrence->line);
     }
 
     private function printErrors(OutputResult $result, OutputInterface $output): void

--- a/src/Supportive/OutputFormatter/ConsoleOutputFormatter.php
+++ b/src/Supportive/OutputFormatter/ConsoleOutputFormatter.php
@@ -83,7 +83,7 @@ final class ConsoleOutputFormatter implements OutputFormatterInterface
         $buffer = implode(
             " -> \n",
             array_map(
-                static fn (array $dependency): string => sprintf("\t%s::%d", $dependency['name'], $dependency['line']),
+                static fn (array $dependency): string => sprintf("\t%s:%d", $dependency['name'], $dependency['line']),
                 $dep->serialize()
             )
         );

--- a/tests/Supportive/OutputFormatter/ConsoleOutputFormatterTest.php
+++ b/tests/Supportive/OutputFormatter/ConsoleOutputFormatterTest.php
@@ -79,11 +79,11 @@ final class ConsoleOutputFormatterTest extends TestCase
             '
                 ClassA must not depend on ClassB (LayerA on LayerB)
                 originalA.php:12
-                ClassInheritD::6 ->
-                ClassInheritC::5 ->
-                ClassInheritB::4 ->
-                ClassInheritA::3 ->
-                OriginalB::12
+                ClassInheritD:6 ->
+                ClassInheritC:5 ->
+                ClassInheritB:4 ->
+                ClassInheritA:3 ->
+                OriginalB:12
 
                 Report:
                 Violations: 1

--- a/tests/Supportive/OutputFormatter/ConsoleOutputFormatterTest.php
+++ b/tests/Supportive/OutputFormatter/ConsoleOutputFormatterTest.php
@@ -78,7 +78,7 @@ final class ConsoleOutputFormatterTest extends TestCase
             'warnings' => [],
             '
                 ClassA must not depend on ClassB (LayerA on LayerB)
-                originalA.php::12
+                originalA.php:12
                 ClassInheritD::6 ->
                 ClassInheritC::5 ->
                 ClassInheritB::4 ->
@@ -108,7 +108,7 @@ final class ConsoleOutputFormatterTest extends TestCase
             'warnings' => [],
             '
                 OriginalA must not depend on OriginalB (LayerA on LayerB)
-                originalA.php::12
+                originalA.php:12
 
                 Report:
                 Violations: 1
@@ -147,7 +147,7 @@ final class ConsoleOutputFormatterTest extends TestCase
             [],
             'warnings' => [],
             '[SKIPPED] OriginalA must not depend on OriginalB (LayerA on LayerB)
-            originalA.php::12
+            originalA.php:12
 
             Report:
             Violations: 0
@@ -171,7 +171,7 @@ final class ConsoleOutputFormatterTest extends TestCase
             '
                 Uncovered dependencies:
                 OriginalA has uncovered dependency on OriginalB (LayerA)
-                originalA.php::12
+                originalA.php:12
                 Report:
                 Violations: 0
                 Skipped violations: 0


### PR DESCRIPTION
This is minor usability improvement. 

At least **PHPStorm does not jump to the line** when I copy current output (with double colon). With single colon, it does.